### PR TITLE
Add support for serializing Decimals

### DIFF
--- a/gwlfe/datamodel.py
+++ b/gwlfe/datamodel.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from decimal import Decimal
 import json
 
 import numpy as np
@@ -301,4 +302,6 @@ class NumpyAwareJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
+        elif isinstance(obj, Decimal):
+            return float(obj)
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
A number of values coming from databases are in this format.

Should fix errors like:

```
[2016-04-13 17:21:52,159: ERROR/Worker-1] Task 294d80e4-dc53-4e21-90a9-4e2a5f8fda10 run from job 1910 raised exception: Decimal('30') is not JSON serializable
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/opt/app/apps/modeling/tasks.py", line 75, in start_gwlfe_job
    response_json = model.tojson() if model else {}
  File "/opt/app/requirements/src/gwlf-e/gwlfe/datamodel.py", line 297, in tojson
    return json.dumps(self.__dict__, cls=NumpyAwareJSONEncoder)
  File "/usr/lib/python2.7/json/__init__.py", line 250, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/opt/app/requirements/src/gwlf-e/gwlfe/datamodel.py", line 304, in default
    return json.JSONEncoder.default(self, obj)
  File "/usr/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: Decimal('30') is not JSON serializable
```