### PR TITLE
Add support for Python arrays

### DIFF
--- a/gwlfe/AFOS.py
+++ b/gwlfe/AFOS.py
@@ -17,157 +17,157 @@ def AnimalOperations(z, Y):
     log.debug('AnimalOperations')
 
     for i in range(12):
-        z.LossFactAdj[Y, i] = (z.Precipitation[Y, i] / z.DaysMonth[Y, i]) / 0.3301
+        z.LossFactAdj[Y][i] = (z.Precipitation[Y][i] / z.DaysMonth[Y][i]) / 0.3301
 
         # Non-grazing animal losses
-        z.NGLostManN[Y, i] = (z.NGAppManN[i] * z.NGAppNRate[i] * z.LossFactAdj[Y, i]
+        z.NGLostManN[Y][i] = (z.NGAppManN[i] * z.NGAppNRate[i] * z.LossFactAdj[Y][i]
                               * (1 - z.NGPctSoilIncRate[i]))
 
-        if z.NGLostManN[Y, i] > z.NGAppManN[i]:
-            z.NGLostManN[Y, i] = z.NGAppManN[i]
-        if z.NGLostManN[Y, i] < 0:
-            z.NGLostManN[Y, i] = 0
+        if z.NGLostManN[Y][i] > z.NGAppManN[i]:
+            z.NGLostManN[Y][i] = z.NGAppManN[i]
+        if z.NGLostManN[Y][i] < 0:
+            z.NGLostManN[Y][i] = 0
 
-        z.NGLostManP[Y, i] = (z.NGAppManP[i] * z.NGAppPRate[i] * z.LossFactAdj[Y, i]
+        z.NGLostManP[Y][i] = (z.NGAppManP[i] * z.NGAppPRate[i] * z.LossFactAdj[Y][i]
                               * (1 - z.NGPctSoilIncRate[i]))
 
-        if z.NGLostManP[Y, i] > z.NGAppManP[i]:
-            z.NGLostManP[Y, i] = z.NGAppManP[i]
-        if z.NGLostManP[Y, i] < 0:
-            z.NGLostManP[Y, i] = 0
+        if z.NGLostManP[Y][i] > z.NGAppManP[i]:
+            z.NGLostManP[Y][i] = z.NGAppManP[i]
+        if z.NGLostManP[Y][i] < 0:
+            z.NGLostManP[Y][i] = 0
 
-        z.NGLostManFC[Y, i] = (z.NGAppManFC[i] * z.NGAppFCRate[i] * z.LossFactAdj[Y, i]
+        z.NGLostManFC[Y][i] = (z.NGAppManFC[i] * z.NGAppFCRate[i] * z.LossFactAdj[Y][i]
                                * (1 - z.NGPctSoilIncRate[i]))
 
-        if z.NGLostManFC[Y, i] > z.NGAppManFC[i]:
-            z.NGLostManFC[Y, i] = z.NGAppManFC[i]
-        if z.NGLostManFC[Y, i] < 0:
-            z.NGLostManFC[Y, i] = 0
+        if z.NGLostManFC[Y][i] > z.NGAppManFC[i]:
+            z.NGLostManFC[Y][i] = z.NGAppManFC[i]
+        if z.NGLostManFC[Y][i] < 0:
+            z.NGLostManFC[Y][i] = 0
 
-        z.NGLostBarnN[Y, i] = (z.NGInitBarnN[i] * z.NGBarnNRate[i] * z.LossFactAdj[Y, i]
-                               - z.NGInitBarnN[i] * z.NGBarnNRate[i] * z.LossFactAdj[Y, i] * z.AWMSNgPct * z.NgAWMSCoeffN
-                               + z.NGInitBarnN[i] * z.NGBarnNRate[i] * z.LossFactAdj[Y, i] * z.RunContPct * z.RunConCoeffN)
+        z.NGLostBarnN[Y][i] = (z.NGInitBarnN[i] * z.NGBarnNRate[i] * z.LossFactAdj[Y][i]
+                               - z.NGInitBarnN[i] * z.NGBarnNRate[i] * z.LossFactAdj[Y][i] * z.AWMSNgPct * z.NgAWMSCoeffN
+                               + z.NGInitBarnN[i] * z.NGBarnNRate[i] * z.LossFactAdj[Y][i] * z.RunContPct * z.RunConCoeffN)
 
-        if z.NGLostBarnN[Y, i] > z.NGInitBarnN[i]:
-            z.NGLostBarnN[Y, i] = z.NGInitBarnN[i]
-        if z.NGLostBarnN[Y, i] < 0:
-            z.NGLostBarnN[Y, i] = 0
+        if z.NGLostBarnN[Y][i] > z.NGInitBarnN[i]:
+            z.NGLostBarnN[Y][i] = z.NGInitBarnN[i]
+        if z.NGLostBarnN[Y][i] < 0:
+            z.NGLostBarnN[Y][i] = 0
 
-        z.NGLostBarnP[Y, i] = (z.NGInitBarnP[i] * z.NGBarnPRate[i] * z.LossFactAdj[Y, i]
-                               - z.NGInitBarnP[i] * z.NGBarnPRate[i] * z.LossFactAdj[Y, i] * z.AWMSNgPct * z.NgAWMSCoeffP
-                               + z.NGInitBarnP[i] * z.NGBarnPRate[i] * z.LossFactAdj[Y, i] * z.RunContPct * z.RunConCoeffP)
+        z.NGLostBarnP[Y][i] = (z.NGInitBarnP[i] * z.NGBarnPRate[i] * z.LossFactAdj[Y][i]
+                               - z.NGInitBarnP[i] * z.NGBarnPRate[i] * z.LossFactAdj[Y][i] * z.AWMSNgPct * z.NgAWMSCoeffP
+                               + z.NGInitBarnP[i] * z.NGBarnPRate[i] * z.LossFactAdj[Y][i] * z.RunContPct * z.RunConCoeffP)
 
-        if z.NGLostBarnP[Y, i] > z.NGInitBarnP[i]:
-            z.NGLostBarnP[Y, i] = z.NGInitBarnP[i]
-        if z.NGLostBarnP[Y, i] < 0:
-            z.NGLostBarnP[Y, i] = 0
+        if z.NGLostBarnP[Y][i] > z.NGInitBarnP[i]:
+            z.NGLostBarnP[Y][i] = z.NGInitBarnP[i]
+        if z.NGLostBarnP[Y][i] < 0:
+            z.NGLostBarnP[Y][i] = 0
 
-        z.NGLostBarnFC[Y, i] = (z.NGInitBarnFC[i] * z.NGBarnFCRate[i] * z.LossFactAdj[Y, i]
-                                - z.NGInitBarnFC[i] * z.NGBarnFCRate[i] * z.LossFactAdj[Y, i] * z.AWMSNgPct * z.NgAWMSCoeffP
-                                + z.NGInitBarnFC[i] * z.NGBarnFCRate[i] * z.LossFactAdj[Y, i] * z.RunContPct * z.RunConCoeffP)
+        z.NGLostBarnFC[Y][i] = (z.NGInitBarnFC[i] * z.NGBarnFCRate[i] * z.LossFactAdj[Y][i]
+                                - z.NGInitBarnFC[i] * z.NGBarnFCRate[i] * z.LossFactAdj[Y][i] * z.AWMSNgPct * z.NgAWMSCoeffP
+                                + z.NGInitBarnFC[i] * z.NGBarnFCRate[i] * z.LossFactAdj[Y][i] * z.RunContPct * z.RunConCoeffP)
 
-        if z.NGLostBarnFC[Y, i] > z.NGInitBarnFC[i]:
-            z.NGLostBarnFC[Y, i] = z.NGInitBarnFC[i]
-        if z.NGLostBarnFC[Y, i] < 0:
-            z.NGLostBarnFC[Y, i] = 0
+        if z.NGLostBarnFC[Y][i] > z.NGInitBarnFC[i]:
+            z.NGLostBarnFC[Y][i] = z.NGInitBarnFC[i]
+        if z.NGLostBarnFC[Y][i] < 0:
+            z.NGLostBarnFC[Y][i] = 0
 
         # Grazing animal losses
-        z.GRLostManN[Y, i] = (z.GRAppManN[i] * z.GRAppNRate[i] * z.LossFactAdj[Y, i]
+        z.GRLostManN[Y][i] = (z.GRAppManN[i] * z.GRAppNRate[i] * z.LossFactAdj[Y][i]
                               * (1 - z.GRPctSoilIncRate[i]))
 
-        if z.GRLostManN[Y, i] > z.GRAppManN[i]:
-            z.GRLostManN[Y, i] = z.GRAppManN[i]
-        if z.GRLostManN[Y, i] < 0:
-            z.GRLostManN[Y, i] = 0
+        if z.GRLostManN[Y][i] > z.GRAppManN[i]:
+            z.GRLostManN[Y][i] = z.GRAppManN[i]
+        if z.GRLostManN[Y][i] < 0:
+            z.GRLostManN[Y][i] = 0
 
-        z.GRLostManP[Y, i] = (z.GRAppManP[i] * z.GRAppPRate[i] * z.LossFactAdj[Y, i]
+        z.GRLostManP[Y][i] = (z.GRAppManP[i] * z.GRAppPRate[i] * z.LossFactAdj[Y][i]
                               * (1 - z.GRPctSoilIncRate[i]))
 
-        if z.GRLostManP[Y, i] > z.GRAppManP[i]:
-            z.GRLostManP[Y, i] = z.GRAppManP[i]
-        if z.GRLostManP[Y, i] < 0:
-            z.GRLostManP[Y, i] = 0
+        if z.GRLostManP[Y][i] > z.GRAppManP[i]:
+            z.GRLostManP[Y][i] = z.GRAppManP[i]
+        if z.GRLostManP[Y][i] < 0:
+            z.GRLostManP[Y][i] = 0
 
-        z.GRLostManFC[Y, i] = (z.GRAppManFC[i] * z.GRAppFCRate[i] * z.LossFactAdj[Y, i]
+        z.GRLostManFC[Y][i] = (z.GRAppManFC[i] * z.GRAppFCRate[i] * z.LossFactAdj[Y][i]
                                * (1 - z.GRPctSoilIncRate[i]))
 
-        if z.GRLostManFC[Y, i] > z.GRAppManFC[i]:
-            z.GRLostManFC[Y, i] = z.GRAppManFC[i]
-        if z.GRLostManFC[Y, i] < 0:
-            z.GRLostManFC[Y, i] = 0
+        if z.GRLostManFC[Y][i] > z.GRAppManFC[i]:
+            z.GRLostManFC[Y][i] = z.GRAppManFC[i]
+        if z.GRLostManFC[Y][i] < 0:
+            z.GRLostManFC[Y][i] = 0
 
-        z.GRLostBarnN[Y, i] = (z.GRInitBarnN[i] * z.GRBarnNRate[i] * z.LossFactAdj[Y, i]
-                               - z.GRInitBarnN[i] * z.GRBarnNRate[i] * z.LossFactAdj[Y, i] * z.AWMSGrPct * z.GrAWMSCoeffN
-                               + z.GRInitBarnN[i] * z.GRBarnNRate[i] * z.LossFactAdj[Y, i] * z.RunContPct * z.RunConCoeffN)
+        z.GRLostBarnN[Y][i] = (z.GRInitBarnN[i] * z.GRBarnNRate[i] * z.LossFactAdj[Y][i]
+                               - z.GRInitBarnN[i] * z.GRBarnNRate[i] * z.LossFactAdj[Y][i] * z.AWMSGrPct * z.GrAWMSCoeffN
+                               + z.GRInitBarnN[i] * z.GRBarnNRate[i] * z.LossFactAdj[Y][i] * z.RunContPct * z.RunConCoeffN)
 
-        if z.GRLostBarnN[Y, i] > z.GRInitBarnN[i]:
-            z.GRLostBarnN[Y, i] = z.GRInitBarnN[i]
-        if z.GRLostBarnN[Y, i] < 0:
-            z.GRLostBarnN[Y, i] = 0
+        if z.GRLostBarnN[Y][i] > z.GRInitBarnN[i]:
+            z.GRLostBarnN[Y][i] = z.GRInitBarnN[i]
+        if z.GRLostBarnN[Y][i] < 0:
+            z.GRLostBarnN[Y][i] = 0
 
-        z.GRLostBarnP[Y, i] = (z.GRInitBarnP[i] * z.GRBarnPRate[i] * z.LossFactAdj[Y, i]
-                               - z.GRInitBarnP[i] * z.GRBarnPRate[i] * z.LossFactAdj[Y, i] * z.AWMSGrPct * z.GrAWMSCoeffP
-                               + z.GRInitBarnP[i] * z.GRBarnPRate[i] * z.LossFactAdj[Y, i] * z.RunContPct * z.RunConCoeffP)
+        z.GRLostBarnP[Y][i] = (z.GRInitBarnP[i] * z.GRBarnPRate[i] * z.LossFactAdj[Y][i]
+                               - z.GRInitBarnP[i] * z.GRBarnPRate[i] * z.LossFactAdj[Y][i] * z.AWMSGrPct * z.GrAWMSCoeffP
+                               + z.GRInitBarnP[i] * z.GRBarnPRate[i] * z.LossFactAdj[Y][i] * z.RunContPct * z.RunConCoeffP)
 
-        if z.GRLostBarnP[Y, i] > z.GRInitBarnP[i]:
-            z.GRLostBarnP[Y, i] = z.GRInitBarnP[i]
-        if z.GRLostBarnP[Y, i] < 0:
-            z.GRLostBarnP[Y, i] = 0
+        if z.GRLostBarnP[Y][i] > z.GRInitBarnP[i]:
+            z.GRLostBarnP[Y][i] = z.GRInitBarnP[i]
+        if z.GRLostBarnP[Y][i] < 0:
+            z.GRLostBarnP[Y][i] = 0
 
-        z.GRLostBarnFC[Y, i] = (z.GRInitBarnFC[i] * z.GRBarnFCRate[i] * z.LossFactAdj[Y, i]
-                                - z.GRInitBarnFC[i] * z.GRBarnFCRate[i] * z.LossFactAdj[Y, i] * z.AWMSGrPct * z.GrAWMSCoeffP
-                                + z.GRInitBarnFC[i] * z.GRBarnFCRate[i] * z.LossFactAdj[Y, i] * z.RunContPct * z.RunConCoeffP)
+        z.GRLostBarnFC[Y][i] = (z.GRInitBarnFC[i] * z.GRBarnFCRate[i] * z.LossFactAdj[Y][i]
+                                - z.GRInitBarnFC[i] * z.GRBarnFCRate[i] * z.LossFactAdj[Y][i] * z.AWMSGrPct * z.GrAWMSCoeffP
+                                + z.GRInitBarnFC[i] * z.GRBarnFCRate[i] * z.LossFactAdj[Y][i] * z.RunContPct * z.RunConCoeffP)
 
-        if z.GRLostBarnFC[Y, i] > z.GRInitBarnFC[i]:
-            z.GRLostBarnFC[Y, i] = z.GRInitBarnFC[i]
-        if z.GRLostBarnFC[Y, i] < 0:
-            z.GRLostBarnFC[Y, i] = 0
+        if z.GRLostBarnFC[Y][i] > z.GRInitBarnFC[i]:
+            z.GRLostBarnFC[Y][i] = z.GRInitBarnFC[i]
+        if z.GRLostBarnFC[Y][i] < 0:
+            z.GRLostBarnFC[Y][i] = 0
 
-        z.GRLossN[Y, i] = ((z.GrazingN[i] - z.GRStreamN[i])
-                           * z.GrazingNRate[i] * z.LossFactAdj[Y, i])
+        z.GRLossN[Y][i] = ((z.GrazingN[i] - z.GRStreamN[i])
+                           * z.GrazingNRate[i] * z.LossFactAdj[Y][i])
 
-        if z.GRLossN[Y, i] > (z.GrazingN[i] - z.GRStreamN[i]):
-            z.GRLossN[Y, i] = (z.GrazingN[i] - z.GRStreamN[i])
-        if z.GRLossN[Y, i] < 0:
-            z.GRLossN[Y, i] = 0
+        if z.GRLossN[Y][i] > (z.GrazingN[i] - z.GRStreamN[i]):
+            z.GRLossN[Y][i] = (z.GrazingN[i] - z.GRStreamN[i])
+        if z.GRLossN[Y][i] < 0:
+            z.GRLossN[Y][i] = 0
 
-        z.GRLossP[Y, i] = ((z.GrazingP[i] - z.GRStreamP[i])
-                           * z.GrazingPRate[i] * z.LossFactAdj[Y, i])
+        z.GRLossP[Y][i] = ((z.GrazingP[i] - z.GRStreamP[i])
+                           * z.GrazingPRate[i] * z.LossFactAdj[Y][i])
 
-        if z.GRLossP[Y, i] > (z.GrazingP[i] - z.GRStreamP[i]):
-            z.GRLossP[Y, i] = (z.GrazingP[i] - z.GRStreamP[i])
-        if z.GRLossP[Y, i] < 0:
-            z.GRLossP[Y, i] = 0
+        if z.GRLossP[Y][i] > (z.GrazingP[i] - z.GRStreamP[i]):
+            z.GRLossP[Y][i] = (z.GrazingP[i] - z.GRStreamP[i])
+        if z.GRLossP[Y][i] < 0:
+            z.GRLossP[Y][i] = 0
 
-        z.GRLossFC[Y, i] = ((z.GrazingFC[i] - z.GRStreamFC[i])
-                            * z.GrazingFCRate[i] * z.LossFactAdj[Y, i])
+        z.GRLossFC[Y][i] = ((z.GrazingFC[i] - z.GRStreamFC[i])
+                            * z.GrazingFCRate[i] * z.LossFactAdj[Y][i])
 
-        if z.GRLossFC[Y, i] > (z.GrazingFC[i] - z.GRStreamFC[i]):
-            z.GRLossFC[Y, i] = (z.GrazingFC[i] - z.GRStreamFC[i])
-        if z.GRLossFC[Y, i] < 0:
-            z.GRLossFC[Y, i] = 0
+        if z.GRLossFC[Y][i] > (z.GrazingFC[i] - z.GRStreamFC[i]):
+            z.GRLossFC[Y][i] = (z.GrazingFC[i] - z.GRStreamFC[i])
+        if z.GRLossFC[Y][i] < 0:
+            z.GRLossFC[Y][i] = 0
 
         # Total animal related losses
-        z.AnimalN[Y, i] = (z.NGLostManN[Y, i]
-                           + z.GRLostManN[Y, i]
-                           + z.NGLostBarnN[Y, i]
-                           + z.GRLostBarnN[Y, i]
-                           + z.GRLossN[Y, i]
+        z.AnimalN[Y][i] = (z.NGLostManN[Y][i]
+                           + z.GRLostManN[Y][i]
+                           + z.NGLostBarnN[Y][i]
+                           + z.GRLostBarnN[Y][i]
+                           + z.GRLossN[Y][i]
                            + z.GRStreamN[i])
 
-        z.AnimalP[Y, i] = ((z.NGLostManP[Y, i]
-                           + z.GRLostManP[Y, i]
-                           + z.NGLostBarnP[Y, i]
-                           + z.GRLostBarnP[Y, i]
-                           + z.GRLossP[Y, i]
+        z.AnimalP[Y][i] = ((z.NGLostManP[Y][i]
+                           + z.GRLostManP[Y][i]
+                           + z.NGLostBarnP[Y][i]
+                           + z.GRLostBarnP[Y][i]
+                           + z.GRLossP[Y][i]
                            + z.GRStreamP[i])
-                           - ((z.NGLostManP[Y, i] + z.NGLostBarnP[Y, i]) * z.PhytasePct * z.PhytaseCoeff))
+                           - ((z.NGLostManP[Y][i] + z.NGLostBarnP[Y][i]) * z.PhytasePct * z.PhytaseCoeff))
 
-        z.AnimalFC[Y, i] = (z.NGLostManFC[Y, i]
-                            + z.GRLostManFC[Y, i]
-                            + z.NGLostBarnFC[Y, i]
-                            + z.GRLostBarnFC[Y, i]
-                            + z.GRLossFC[Y, i]
+        z.AnimalFC[Y][i] = (z.NGLostManFC[Y][i]
+                            + z.GRLostManFC[Y][i]
+                            + z.NGLostBarnFC[Y][i]
+                            + z.GRLostBarnFC[Y][i]
+                            + z.GRLossFC[Y][i]
                             + z.GRStreamFC[i])
 
         # CACULATE PATHOGEN LOADS
@@ -177,44 +177,44 @@ def AnimalOperations(z, Y):
         z.PtFlowLiters = (z.PointFlow[i] / 100) * z.TotAreaMeters * 1000
 
         # Get the wildlife orgs
-        z.WWOrgs[Y, i] = z.PtFlowLiters * (z.WWTPConc * 10) * (1 - z.InstreamDieoff)
-        z.SSOrgs[Y, i] = (z.SepticOrgsDay
+        z.WWOrgs[Y][i] = z.PtFlowLiters * (z.WWTPConc * 10) * (1 - z.InstreamDieoff)
+        z.SSOrgs[Y][i] = (z.SepticOrgsDay
                           * z.SepticsDay[i]
-                          * z.DaysMonth[Y, i]
+                          * z.DaysMonth[Y][i]
                           * z.SepticFailure
                           * (1 - z.InstreamDieoff))
 
-        if z.LossFactAdj[Y, i] * (1 - z.WuDieoff) > 1:
-            z.UrbOrgs[Y, i] = (z.UrbRunoffLiter[Y, i]
+        if z.LossFactAdj[Y][i] * (1 - z.WuDieoff) > 1:
+            z.UrbOrgs[Y][i] = (z.UrbRunoffLiter[Y][i]
                                * (z.UrbEMC * 10)
                                * (1 - z.InstreamDieoff))
-            z.WildOrgs[Y, i] = (z.WildOrgsDay
-                                * z.DaysMonth[Y, i]
+            z.WildOrgs[Y][i] = (z.WildOrgsDay
+                                * z.DaysMonth[Y][i]
                                 * z.WildDensity
                                 * z.ForestAreaTotalSqMi
                                 * (1 - z.InstreamDieoff))
         else:
-            z.UrbOrgs[Y, i] = (z.UrbRunoffLiter[Y, i]
+            z.UrbOrgs[Y][i] = (z.UrbRunoffLiter[Y][i]
                                * (z.UrbEMC * 10)
                                * (1 - z.WuDieoff)
                                * (1 - z.InstreamDieoff))
-            z.WildOrgs[Y, i] = (z.WildOrgsDay
-                                * z.DaysMonth[Y, i]
+            z.WildOrgs[Y][i] = (z.WildOrgsDay
+                                * z.DaysMonth[Y][i]
                                 * z.WildDensity
                                 * z.ForestAreaTotalSqMi
                                 * (1 - z.WuDieoff)
                                 * (1 - z.InstreamDieoff))
 
         # Get the total orgs
-        z.TotalOrgs[Y, i] = (z.WWOrgs[Y, i]
-                             + z.SSOrgs[Y, i]
-                             + z.UrbOrgs[Y, i]
-                             + z.WildOrgs[Y, i]
-                             + z.AnimalFC[Y, i])
+        z.TotalOrgs[Y][i] = (z.WWOrgs[Y][i]
+                             + z.SSOrgs[Y][i]
+                             + z.UrbOrgs[Y][i]
+                             + z.WildOrgs[Y][i]
+                             + z.AnimalFC[Y][i])
 
-        z.CMStream[Y, i] = (z.StreamFlow[Y, i] / 100) * z.TotAreaMeters
+        z.CMStream[Y][i] = (z.StreamFlow[Y][i] / 100) * z.TotAreaMeters
 
-        if z.CMStream[Y, i] > 0:
-            z.OrgConc[Y, i] = (z.TotalOrgs[Y, i] / (z.CMStream[Y, i] * 1000)) / 10
+        if z.CMStream[Y][i] > 0:
+            z.OrgConc[Y][i] = (z.TotalOrgs[Y][i] / (z.CMStream[Y][i] * 1000)) / 10
         else:
-            z.OrgConc[Y, i] = 0
+            z.OrgConc[Y][i] = 0

--- a/gwlfe/AnnualMeans.py
+++ b/gwlfe/AnnualMeans.py
@@ -22,88 +22,88 @@ def CalculateAnnualMeanLoads(z, Y):
 
     # Add the Stream Bank Erosion to sediment yield
     for i in range(12):
-        z.SedYield[Y, i] += z.StreamBankEros[Y, i] / 1000
+        z.SedYield[Y][i] += z.StreamBankEros[Y][i] / 1000
 
     z.CalendarYr = z.WxYrBeg + (Y - 1)
 
     # CALCULATE ANNUAL MEANS FOR STREAM BANK AND TILE DRAINAGE VALUES
     for i in range(12):
-        z.AvStreamBankEros[i] += z.StreamBankEros[Y, i] / z.NYrs
-        z.AvStreamBankN[i] += z.StreamBankN[Y, i] / z.NYrs
-        z.AvStreamBankP[i] += z.StreamBankP[Y, i] / z.NYrs
+        z.AvStreamBankEros[i] += z.StreamBankEros[Y][i] / z.NYrs
+        z.AvStreamBankN[i] += z.StreamBankN[Y][i] / z.NYrs
+        z.AvStreamBankP[i] += z.StreamBankP[Y][i] / z.NYrs
 
         # If the Monthly Erosion is < the Sediment Yield
         # recalculate using Sediment Delivery Ratio
-        if z.SedDelivRatio > 0 and z.Erosion[Y, i] < z.SedYield[Y, i]:
-            z.Erosion[Y, i] = z.SedYield[Y, i] / z.SedDelivRatio
+        if z.SedDelivRatio > 0 and z.Erosion[Y][i] < z.SedYield[Y][i]:
+            z.Erosion[Y][i] = z.SedYield[Y][i] / z.SedDelivRatio
 
-        z.AvPtSrcFlow[i] += z.PtSrcFlow[Y, i] / z.NYrs
-        z.AvTileDrain[i] += z.TileDrain[Y, i] / z.NYrs
-        z.AvWithdrawal[i] += z.Withdrawal[Y, i] / z.NYrs
-        z.AvTileDrainN[i] += z.TileDrainN[Y, i] / z.NYrs
-        z.AvTileDrainP[i] += z.TileDrainP[Y, i] / z.NYrs
-        z.AvTileDrainSed[i] += z.TileDrainSed[Y, i] / z.NYrs
+        z.AvPtSrcFlow[i] += z.PtSrcFlow[Y][i] / z.NYrs
+        z.AvTileDrain[i] += z.TileDrain[Y][i] / z.NYrs
+        z.AvWithdrawal[i] += z.Withdrawal[Y][i] / z.NYrs
+        z.AvTileDrainN[i] += z.TileDrainN[Y][i] / z.NYrs
+        z.AvTileDrainP[i] += z.TileDrainP[Y][i] / z.NYrs
+        z.AvTileDrainSed[i] += z.TileDrainSed[Y][i] / z.NYrs
 
     # Recalculate the total annual erosion
     z.ErosSum = 0
     for i in range(12):
-        z.ErosSum += z.Erosion[Y, i]
-    z.Erosion[Y, 0] = z.ErosSum
+        z.ErosSum += z.Erosion[Y][i]
+    z.Erosion[Y][0] = z.ErosSum
 
     # COMPUTE ANNUAL MEANS
     for i in range(12):
-        z.AvPrecipitation[i] += z.Precipitation[Y, i] / z.NYrs
-        z.AvEvapoTrans[i] += z.Evapotrans[Y, i] / z.NYrs
-        z.AvGroundWater[i] += z.GroundWatLE[Y, i] / z.NYrs
+        z.AvPrecipitation[i] += z.Precipitation[Y][i] / z.NYrs
+        z.AvEvapoTrans[i] += z.Evapotrans[Y][i] / z.NYrs
+        z.AvGroundWater[i] += z.GroundWatLE[Y][i] / z.NYrs
 
         if z.AvGroundWater[i] < 0:
             z.AvGroundWater[i] = 0
 
-        z.AvRunoff[i] += z.Runoff[Y, i] / z.NYrs
-        z.AvErosion[i] += z.Erosion[Y, i] / z.NYrs
-        z.AvSedYield[i] += z.SedYield[Y, i] / z.NYrs
+        z.AvRunoff[i] += z.Runoff[Y][i] / z.NYrs
+        z.AvErosion[i] += z.Erosion[Y][i] / z.NYrs
+        z.AvSedYield[i] += z.SedYield[Y][i] / z.NYrs
 
-        z.AvDisNitr[i] += z.DisNitr[Y, i] / z.NYrs
-        z.AvTotNitr[i] += z.TotNitr[Y, i] / z.NYrs
-        z.AvDisPhos[i] += z.DisPhos[Y, i] / z.NYrs
-        z.AvTotPhos[i] += z.TotPhos[Y, i] / z.NYrs
-        z.AvGroundNitr[i] += z.GroundNitr[Y, i] / z.NYrs
-        z.AvGroundPhos[i] += z.GroundPhos[Y, i] / z.NYrs
-        z.AvAnimalN[i] += z.AnimalN[Y, i] / z.NYrs
-        z.AvAnimalP[i] += z.AnimalP[Y, i] / z.NYrs
+        z.AvDisNitr[i] += z.DisNitr[Y][i] / z.NYrs
+        z.AvTotNitr[i] += z.TotNitr[Y][i] / z.NYrs
+        z.AvDisPhos[i] += z.DisPhos[Y][i] / z.NYrs
+        z.AvTotPhos[i] += z.TotPhos[Y][i] / z.NYrs
+        z.AvGroundNitr[i] += z.GroundNitr[Y][i] / z.NYrs
+        z.AvGroundPhos[i] += z.GroundPhos[Y][i] / z.NYrs
+        z.AvAnimalN[i] += z.AnimalN[Y][i] / z.NYrs
+        z.AvAnimalP[i] += z.AnimalP[Y][i] / z.NYrs
 
-        z.AvGRLostBarnN[i] += z.GRLostBarnN[Y, i] / z.NYrs
-        z.AvGRLostBarnP[i] += z.GRLostBarnP[Y, i] / z.NYrs
-        z.AvGRLostBarnFC[i] += z.GRLostBarnFC[Y, i] / z.NYrs
+        z.AvGRLostBarnN[i] += z.GRLostBarnN[Y][i] / z.NYrs
+        z.AvGRLostBarnP[i] += z.GRLostBarnP[Y][i] / z.NYrs
+        z.AvGRLostBarnFC[i] += z.GRLostBarnFC[Y][i] / z.NYrs
 
-        z.AvNGLostBarnN[i] += z.NGLostBarnN[Y, i] / z.NYrs
-        z.AvNGLostBarnP[i] += z.NGLostBarnP[Y, i] / z.NYrs
-        z.AvNGLostBarnFC[i] += z.NGLostBarnFC[Y, i] / z.NYrs
+        z.AvNGLostBarnN[i] += z.NGLostBarnN[Y][i] / z.NYrs
+        z.AvNGLostBarnP[i] += z.NGLostBarnP[Y][i] / z.NYrs
+        z.AvNGLostBarnFC[i] += z.NGLostBarnFC[Y][i] / z.NYrs
 
-        z.AvNGLostManP[i] += z.NGLostManP[Y, i] / z.NYrs
+        z.AvNGLostManP[i] += z.NGLostManP[Y][i] / z.NYrs
 
         # Average pathogen totals
-        z.AvAnimalFC[i] += z.AnimalFC[Y, i] / z.NYrs
-        z.AvWWOrgs[i] += z.WWOrgs[Y, i] / z.NYrs
-        z.AvSSOrgs[i] += z.SSOrgs[Y, i] / z.NYrs
-        z.AvUrbOrgs[i] += z.UrbOrgs[Y, i] / z.NYrs
-        z.AvWildOrgs[i] += z.WildOrgs[Y, i] / z.NYrs
-        z.AvTotalOrgs[i] += z.TotalOrgs[Y, i] / z.NYrs
+        z.AvAnimalFC[i] += z.AnimalFC[Y][i] / z.NYrs
+        z.AvWWOrgs[i] += z.WWOrgs[Y][i] / z.NYrs
+        z.AvSSOrgs[i] += z.SSOrgs[Y][i] / z.NYrs
+        z.AvUrbOrgs[i] += z.UrbOrgs[Y][i] / z.NYrs
+        z.AvWildOrgs[i] += z.WildOrgs[Y][i] / z.NYrs
+        z.AvTotalOrgs[i] += z.TotalOrgs[Y][i] / z.NYrs
 
     # Average loads for each landuse
     for l in range(z.NRur):
-        z.AvLuRunoff[l] += z.LuRunoff[Y, l] / z.NYrs
-        z.AvLuErosion[l] += z.LuErosion[Y, l] / z.NYrs
-        z.AvLuSedYield[l] += z.LuSedYield[Y, l] / z.NYrs
-        z.AvLuDisNitr[l] += z.LuDisNitr[Y, l] / z.NYrs
-        z.AvLuTotNitr[l] += z.LuTotNitr[Y, l] / z.NYrs
-        z.AvLuDisPhos[l] += z.LuDisPhos[Y, l] / z.NYrs
-        z.AvLuTotPhos[l] += z.LuTotPhos[Y, l] / z.NYrs
+        z.AvLuRunoff[l] += z.LuRunoff[Y][l] / z.NYrs
+        z.AvLuErosion[l] += z.LuErosion[Y][l] / z.NYrs
+        z.AvLuSedYield[l] += z.LuSedYield[Y][l] / z.NYrs
+        z.AvLuDisNitr[l] += z.LuDisNitr[Y][l] / z.NYrs
+        z.AvLuTotNitr[l] += z.LuTotNitr[Y][l] / z.NYrs
+        z.AvLuDisPhos[l] += z.LuDisPhos[Y][l] / z.NYrs
+        z.AvLuTotPhos[l] += z.LuTotPhos[Y][l] / z.NYrs
 
     for l in range(z.NRur, z.NLU):
-        z.AvLuRunoff[l] += z.LuRunoff[Y, l] / z.NYrs
-        z.AvLuTotNitr[l] += z.LuTotNitr[Y, l] / z.NYrs
-        z.AvLuTotPhos[l] += z.LuTotPhos[Y, l] / z.NYrs
-        z.AvLuDisNitr[l] += z.LuDisNitr[Y, l] / z.NYrs
-        z.AvLuDisPhos[l] += z.LuDisPhos[Y, l] / z.NYrs
-        z.AvLuSedYield[l] += z.LuSedYield[Y, l] / z.NYrs
+        z.AvLuRunoff[l] += z.LuRunoff[Y][l] / z.NYrs
+        z.AvLuTotNitr[l] += z.LuTotNitr[Y][l] / z.NYrs
+        z.AvLuTotPhos[l] += z.LuTotPhos[Y][l] / z.NYrs
+        z.AvLuDisNitr[l] += z.LuDisNitr[Y][l] / z.NYrs
+        z.AvLuDisPhos[l] += z.LuDisPhos[Y][l] / z.NYrs
+        z.AvLuSedYield[l] += z.LuSedYield[Y][l] / z.NYrs

--- a/gwlfe/CalcCnErosRunoffSed.py
+++ b/gwlfe/CalcCnErosRunoffSed.py
@@ -38,21 +38,21 @@ def CalcCN(z, i, Y, j):
                 if grow_factor > 0:
                     # growing season
                     if z.AMC5 >= 5.33:
-                        z.CNum = z.NewCN[2, l]
+                        z.CNum = z.NewCN[2][l]
                     elif z.AMC5 < 3.56:
-                        z.CNum = z.NewCN[0, l] + (z.CN[l] - z.NewCN[0, l]) * z.AMC5 / 3.56
+                        z.CNum = z.NewCN[0][l] + (z.CN[l] - z.NewCN[0][l]) * z.AMC5 / 3.56
                     else:
-                        z.CNum = z.CN[l] + (z.NewCN[2, l] - z.CN[l]) * (z.AMC5 - 3.56) / 1.77
+                        z.CNum = z.CN[l] + (z.NewCN[2][l] - z.CN[l]) * (z.AMC5 - 3.56) / 1.77
                 else:
                     # dormant season
                     if z.AMC5 >= 2.79:
-                        z.CNum = z.NewCN[2, l]
+                        z.CNum = z.NewCN[2][l]
                     elif z.AMC5 < 1.27:
-                        z.CNum = z.NewCN[0, l] + (z.CN[l] - z.NewCN[0, l]) * z.AMC5 / 1.27
+                        z.CNum = z.NewCN[0][l] + (z.CN[l] - z.NewCN[0][l]) * z.AMC5 / 1.27
                     else:
-                        z.CNum = z.CN[l] + (z.NewCN[2, l] - z.CN[l]) * (z.AMC5 - 1.27) / 1.52
+                        z.CNum = z.CN[l] + (z.NewCN[2][l] - z.CN[l]) * (z.AMC5 - 1.27) / 1.52
             else:
-                z.CNum = z.NewCN[2, l]
+                z.CNum = z.NewCN[2][l]
 
             z.Retention = 2540 / z.CNum - 25.4
             if z.Retention < 0:
@@ -62,29 +62,29 @@ def CalcCN(z, i, Y, j):
             if z.Water >= 0.2 * z.Retention:
                 z.Qrun = (z.Water - 0.2 * z.Retention) ** 2 / (z.Water + 0.8 * z.Retention)
                 z.RuralQTotal += z.Qrun * z.Area[l] / z.RurAreaTotal
-                z.RurQRunoff[l, i] += z.Qrun
+                z.RurQRunoff[l][i] += z.Qrun
                 # TODO: (what is done with "DayQRunoff"? - appears not to be used)
-                z.DayQRunoff[Y, i, j] = z.Qrun
+                z.DayQRunoff[Y][i][j] = z.Qrun
                 # TODO: (What is done with "AgQRunoff? - apparently nothing)
                 if z.Landuse[l] is LandUse.CROPLAND:
                     # (Maybe used for STREAMPLAN?)
                     z.AgQTotal += z.Qrun * z.Area[l]
-                    z.AgQRunoff[l, i] += z.Qrun
+                    z.AgQRunoff[l][i] += z.Qrun
                 elif z.Landuse[l] is LandUse.HAY_PAST:
                     z.AgQTotal += z.Qrun * z.Area[l]
-                    z.AgQRunoff[l, i] += z.Qrun
+                    z.AgQRunoff[l][i] += z.Qrun
                 elif z.Landuse[l] is LandUse.TURFGRASS:
                     z.AgQTotal = z.Qrun * z.Area[l]
-                    z.AgQRunoff[l, i] += z.Qrun
+                    z.AgQRunoff[l][i] += z.Qrun
             else:
                 z.Qrun = 0
 
         # EROSION, SEDIMENT WASHOFF FOR RURAL AND URBAN LANDUSE
         z.RurEros = 1.32 * z.Erosiv * z.KF[l] * z.LS[l] * z.C[l] * z.P[l] * z.Area[l]
 
-        z.Erosion[Y, i] = z.Erosion[Y, i] + z.RurEros
-        z.ErosWashoff[l, i] = z.ErosWashoff[l, i] + z.RurEros
-        z.DayErWashoff[l, Y, i, j] = z.RurEros
+        z.Erosion[Y][i] = z.Erosion[Y][i] + z.RurEros
+        z.ErosWashoff[l][i] = z.ErosWashoff[l][i] + z.RurEros
+        z.DayErWashoff[l][Y][i][j] = z.RurEros
 
         if z.SedDelivRatio == 0:
             z.SedDelivRatio = 0.0001
@@ -107,26 +107,26 @@ def CalcCN(z, i, Y, j):
         grow_factor = GrowFlag.intval(z.Grow[i])
 
         # Find curve number
-        if z.CNI[1, l] > 0:
+        if z.CNI[1][l] > 0:
             if z.Melt <= 0:
                 if grow_factor > 0:
                     # Growing season
                     if z.AMC5 >= 5.33:
-                        z.CNumImperv = z.CNI[2, l]
+                        z.CNumImperv = z.CNI[2][l]
                     elif z.AMC5 < 3.56:
-                        z.CNumImperv = z.CNI[0, l] + (z.CNI[1, l] - z.CNI[0, l]) * z.AMC5 / 3.56
+                        z.CNumImperv = z.CNI[0][l] + (z.CNI[1][l] - z.CNI[0][l]) * z.AMC5 / 3.56
                     else:
-                        z.CNumImperv = z.CNI[1, l] + (z.CNI[2, l] - z.CNI[1, l]) * (z.AMC5 - 3.56) / 1.77
+                        z.CNumImperv = z.CNI[1][l] + (z.CNI[2][l] - z.CNI[1][l]) * (z.AMC5 - 3.56) / 1.77
                 else:
                     # Dormant season
                     if z.AMC5 >= 2.79:
-                        z.CNumImperv = z.CNI[2, l]
+                        z.CNumImperv = z.CNI[2][l]
                     elif z.AMC5 < 1.27:
-                        z.CNumImperv = z.CNI[0, l] + (z.CNI[1, l] - z.CNI[0, l]) * z.AMC5 / 1.27
+                        z.CNumImperv = z.CNI[0][l] + (z.CNI[1][l] - z.CNI[0][l]) * z.AMC5 / 1.27
                     else:
-                        z.CNumImperv = z.CNI[1, l] + (z.CNI[2, l] - z.CNI[1, l]) * (z.AMC5 - 1.27) / 1.52
+                        z.CNumImperv = z.CNI[1][l] + (z.CNI[2][l] - z.CNI[1][l]) * (z.AMC5 - 1.27) / 1.52
             else:
-                z.CNumImperv = z.CNI[2, l]
+                z.CNumImperv = z.CNI[2][l]
 
             z.CNumImpervReten = 2540 / z.CNumImperv - 25.4
             if z.CNumImpervReten < 0:
@@ -135,26 +135,26 @@ def CalcCN(z, i, Y, j):
             if z.Water >= 0.2 * z.CNumImpervReten:
                 z.QrunI[l] = (z.Water - 0.2 * z.CNumImpervReten) ** 2 / (z.Water + 0.8 * z.CNumImpervReten)
 
-        if z.CNP[1, l] > 0:
+        if z.CNP[1][l] > 0:
             if z.Melt <= 0:
                 if grow_factor > 0:
                     # Growing season
                     if z.AMC5 >= 5.33:
-                        z.CNumPerv = z.CNP[2, l]
+                        z.CNumPerv = z.CNP[2][l]
                     elif z.AMC5 < 3.56:
-                        z.CNumPerv = z.CNP[0, l] + (z.CNP[1, l] - z.CNP[0, l]) * z.AMC5 / 3.56
+                        z.CNumPerv = z.CNP[0][l] + (z.CNP[1][l] - z.CNP[0][l]) * z.AMC5 / 3.56
                     else:
-                        z.CNumPerv = z.CNP[1, l] + (z.CNP[2, l] - z.CNP[1, l]) * (z.AMC5 - 3.56) / 1.77
+                        z.CNumPerv = z.CNP[1][l] + (z.CNP[2][l] - z.CNP[1][l]) * (z.AMC5 - 3.56) / 1.77
                 else:
                     # Dormant season
                     if z.AMC5 >= 2.79:
-                        z.CNumPerv = z.CNP[2, l]
+                        z.CNumPerv = z.CNP[2][l]
                     elif z.AMC5 < 1.27:
-                        z.CNumPerv = z.CNP[0, l] + (z.CNP[1, l] - z.CNP[0, l]) * z.AMC5 / 1.27
+                        z.CNumPerv = z.CNP[0][l] + (z.CNP[1][l] - z.CNP[0][l]) * z.AMC5 / 1.27
                     else:
-                        z.CNumPerv = z.CNP[1, l] + (z.CNP[2, l] - z.CNP[1, l]) * (z.AMC5 - 1.27) / 1.52
+                        z.CNumPerv = z.CNP[1][l] + (z.CNP[2][l] - z.CNP[1][l]) * (z.AMC5 - 1.27) / 1.52
             else:
-                z.CNumPerv = z.CNP[2, l]
+                z.CNumPerv = z.CNP[2][l]
 
             z.CNumPervReten = 2540 / z.CNumPerv - 25.4
             if z.CNumPervReten < 0:
@@ -180,7 +180,7 @@ def CalcCN(z, i, Y, j):
         z.WashPerv[l] = (1 - math.exp(-1.81 * z.QrunP[l])) * z.PervAccum[l]
         z.PervAccum[l] -= z.WashPerv[l]
 
-        z.UrbQRunoff[l, i] += (z.QrunI[l] * (z.Imper[l] * (1 - z.ISRR[lu]) * (1 - z.ISRA[lu]))
+        z.UrbQRunoff[l][i] += (z.QrunI[l] * (z.Imper[l] * (1 - z.ISRR[lu]) * (1 - z.ISRA[lu]))
                                + z.QrunP[l] * (1 - (z.Imper[l] * (1 - z.ISRR[lu]) * (1 - z.ISRA[lu]))))
 
     z.AdjUrbanQTotal = z.UrbanQTotal
@@ -262,21 +262,21 @@ def BasinWater(z, i, Y, j):
                 z.DisBasinMass[q] = 0
 
                 if z.Storm > 0:
-                    z.UrbLoadRed = (z.Water / z.Storm) * z.UrbBMPRed[l, q]
+                    z.UrbLoadRed = (z.Water / z.Storm) * z.UrbBMPRed[l][q]
                 else:
                     z.UrbLoadRed = 0
 
                 if z.Water > z.Storm:
-                    z.UrbLoadRed = z.UrbBMPRed[l, q]
+                    z.UrbLoadRed = z.UrbBMPRed[l][q]
 
                 # TODO: Should 11 be NRur + 1?
                 # What is this trying to do?
                 lu = l - 11
 
                 if z.Area[l] > 0:
-                    z.SurfaceLoad = (((z.LoadRateImp[l, q] * z.WashImperv[l] * ((z.Imper[l] * (1 - z.ISRR[lu]) * (1 - z.ISRA[lu]))
+                    z.SurfaceLoad = (((z.LoadRateImp[l][q] * z.WashImperv[l] * ((z.Imper[l] * (1 - z.ISRR[lu]) * (1 - z.ISRA[lu]))
                                        * (z.SweepFrac[i] + ((1 - z.SweepFrac[i]) * ((1 - z.UrbSweepFrac) * z.Area[l]) / z.Area[l])))
-                                      + z.LoadRatePerv[l, q] * z.WashPerv[l] * (1 - (z.Imper[l] * (1 - z.ISRR[lu]) * (1 - z.ISRA[lu]))))
+                                      + z.LoadRatePerv[l][q] * z.WashPerv[l] * (1 - (z.Imper[l] * (1 - z.ISRR[lu]) * (1 - z.ISRA[lu]))))
                                       * z.Area[l]) - z.UrbLoadRed)
                 else:
                     z.SurfaceLoad = 0
@@ -284,7 +284,7 @@ def BasinWater(z, i, Y, j):
                 if z.SurfaceLoad < 0:
                     z.SurfaceLoad = 0
 
-                z.DisSurfLoad = z.DisFract[l, q] * z.SurfaceLoad
+                z.DisSurfLoad = z.DisFract[l][q] * z.SurfaceLoad
 
                 # Apply Bioretention and/or Stream Buffer BMP
                 z.SurfaceLoad *= (1 - z.RetentionEff) * (1 - (z.FilterEff * z.PctStrmBuf))
@@ -304,27 +304,27 @@ def BasinWater(z, i, Y, j):
                     z.SurfaceLoad -= z.DissolvedLoad + z.SolidLoad
                     z.DisSurfLoad -= z.DissolvedLoad
 
-                    z.LuLoad[Y, l, q] += z.DissolvedLoad + z.SolidLoad
-                    z.LuDisLoad[Y, l, q] += z.DissolvedLoad
+                    z.LuLoad[Y][l][q] += z.DissolvedLoad + z.SolidLoad
+                    z.LuDisLoad[Y][l][q] += z.DissolvedLoad
 
                     z.NetDisLoad[q] += z.DissolvedLoad
                     z.NetSolidLoad[q] += z.SolidLoad
                 else:
-                    z.LuLoad[Y, l, q] += z.SurfaceLoad
-                    z.LuDisLoad[Y, l, q] += z.DisSurfLoad
+                    z.LuLoad[Y][l][q] += z.SurfaceLoad
+                    z.LuDisLoad[Y][l][q] += z.DisSurfLoad
 
                     z.NetDisLoad[q] += z.DisSurfLoad
                     z.NetSolidLoad[q] += z.SurfaceLoad - z.DisSurfLoad
 
     for q in range(z.Nqual):
-        z.Load[Y, i, q] += z.NetDisLoad[q] + z.NetSolidLoad[q]
-        z.DisLoad[Y, i, q] += z.NetDisLoad[q]
+        z.Load[Y][i][q] += z.NetDisLoad[q] + z.NetSolidLoad[q]
+        z.DisLoad[Y][i][q] += z.NetDisLoad[q]
 
-        if z.Load[Y, i, q] < 0:
-            z.Load[Y, i, q] = 0
+        if z.Load[Y][i][q] < 0:
+            z.Load[Y][i][q] = 0
 
-        if z.DisLoad[Y, i, q] < 0:
-            z.DisLoad[Y, i, q] = 0
+        if z.DisLoad[Y][i][q] < 0:
+            z.DisLoad[Y][i][q] = 0
 
     # WATERSHED TOTALS
     if z.RurAreaTotal > 0:
@@ -351,27 +351,27 @@ def BasinWater(z, i, Y, j):
     # Assume 20% reduction of runoff with urban wetlands
     z.AdjQTotal = (z.AdjUrbanQTotal * (1 - (z.n25b * 0.2))) + z.RuralQTotal
 
-    z.SedTrans[Y, i] += z.AdjQTotal ** 1.67
+    z.SedTrans[Y][i] += z.AdjQTotal ** 1.67
 
     # Calculate monthly runoff for year Y and month i
     if z.AdjQTotal > 0:
-        z.Runoff[Y, i] += z.AdjQTotal
+        z.Runoff[Y][i] += z.AdjQTotal
     else:
-        z.Runoff[Y, i] += z.QTotal
+        z.Runoff[Y][i] += z.QTotal
 
-    z.RuralRunoff[Y, i] += z.RuralQTotal
-    z.UrbanRunoff[Y, i] += z.UrbanQTotal
+    z.RuralRunoff[Y][i] += z.RuralQTotal
+    z.UrbanRunoff[Y][i] += z.UrbanQTotal
     # TODO: (Are z.AgRunoff and z.AgQTotal actually in cm?)
-    z.AgRunoff[Y, i] += z.AgQTotal
+    z.AgRunoff[Y][i] += z.AgQTotal
 
     # Convert Urban runoff from cm to Liters
-    # TODO: (Maybe use z.UrbanRunoff[y, i] instead in the above equation)
-    z.UrbRunoffLiter[Y, i] = (z.UrbanRunoff[Y, i] / 100) * z.UrbAreaTotal * 10000 * 1000
+    # TODO: (Maybe use z.UrbanRunoff[y][i] instead in the above equation)
+    z.UrbRunoffLiter[Y][i] = (z.UrbanRunoff[Y][i] / 100) * z.UrbAreaTotal * 10000 * 1000
 
     # Calculate Daily runoff (used in output for daily flow file)
     if z.AdjQTotal > 0:
-        z.DayRunoff[Y, i, j] = z.AdjQTotal
+        z.DayRunoff[Y][i][j] = z.AdjQTotal
     elif z.QTotal > 0:
-        z.DayRunoff[Y, i, j] = z.QTotal
+        z.DayRunoff[Y][i][j] = z.QTotal
     else:
-        z.DayRunoff[Y, i, j] = 0
+        z.DayRunoff[Y][i][j] = 0

--- a/gwlfe/CalcLoads.py
+++ b/gwlfe/CalcLoads.py
@@ -40,33 +40,33 @@ def CalculateLoads(z, Y):
 
     # CALCULATE THE MONTHLY WATER BALANCE FOR STREAM Flow FOR EACH YEAR OF THE ANALYSIS
     for i in range(12):
-        z.StreamFlow[Y, i] = (z.Runoff[Y, i]
-                              + z.GroundWatLE[Y, i]
-                              + z.PtSrcFlow[Y, i]
-                              + z.TileDrain[Y, i]
-                              - z.Withdrawal[Y, i])
+        z.StreamFlow[Y][i] = (z.Runoff[Y][i]
+                              + z.GroundWatLE[Y][i]
+                              + z.PtSrcFlow[Y][i]
+                              + z.TileDrain[Y][i]
+                              - z.Withdrawal[Y][i])
 
-        z.StreamFlowLE[Y, i] = z.StreamFlow[Y, i]
-        if z.StreamFlowLE[Y, i] < 0:
-            z.StreamFlowLE[Y, i] = 0
+        z.StreamFlowLE[Y][i] = z.StreamFlow[Y][i]
+        if z.StreamFlowLE[Y][i] < 0:
+            z.StreamFlowLE[Y][i] = 0
 
     # ANNUAL WATER BALANCE CALCULATIONS
     for i in range(12):
         # Calculate landuse runoff for rural areas
         for l in range(z.NRur):
-            z.LuRunoff[Y, l] += z.RurQRunoff[l, i]
+            z.LuRunoff[Y][l] += z.RurQRunoff[l][i]
 
         # Calculate landuse runoff for urban areas
         for l in range(z.NRur, z.NLU):
-            z.LuRunoff[Y, l] += z.UrbQRunoff[l, i]
+            z.LuRunoff[Y][l] += z.UrbQRunoff[l][i]
 
-        PrecipitationTotal += z.Precipitation[Y, i]
-        RunoffTotal += z.Runoff[Y, i]
-        GroundWatLETotal += z.GroundWatLE[Y, i]
-        EvapotransTotal += z.Evapotrans[Y, i]
-        PtSrcFlowTotal += z.PtSrcFlow[Y, i]
-        WithdrawalTotal += z.Withdrawal[Y, i]
-        StreamFlowTotal += z.StreamFlow[Y, i]
+        PrecipitationTotal += z.Precipitation[Y][i]
+        RunoffTotal += z.Runoff[Y][i]
+        GroundWatLETotal += z.GroundWatLE[Y][i]
+        EvapotransTotal += z.Evapotrans[Y][i]
+        PtSrcFlowTotal += z.PtSrcFlow[Y][i]
+        WithdrawalTotal += z.Withdrawal[Y][i]
+        StreamFlowTotal += z.StreamFlow[Y][i]
 
     # CALCULATE ANNUAL NITROGEN  LOADS FROM NORMAL SEPTIC SYSTEMS
     AnNormNitr = 0
@@ -79,23 +79,23 @@ def CalculateLoads(z, Y):
     for i in range(12):
         z.BSed[i] = 0
         for m in range(i, 12):
-            z.BSed[i] += z.SedTrans[Y, m]
+            z.BSed[i] += z.SedTrans[Y][m]
         for m in range(i):
             if z.BSed[m] > 0:
-                z.SedYield[Y, i] += z.Erosion[Y, m] / z.BSed[m]
+                z.SedYield[Y][i] += z.Erosion[Y][m] / z.BSed[m]
 
-        z.SedYield[Y, i] = z.SedDelivRatio * z.SedTrans[Y, i] * z.SedYield[Y, i]
-        SedYieldTotal += z.SedYield[Y, i]
-        ErosionTotal += z.Erosion[Y, i]
+        z.SedYield[Y][i] = z.SedDelivRatio * z.SedTrans[Y][i] * z.SedYield[Y][i]
+        SedYieldTotal += z.SedYield[Y][i]
+        ErosionTotal += z.Erosion[Y][i]
 
         # CALCULATION OF THE LANDUSE EROSION AND SEDIMENT YIELDS
         for l in range(z.NRur):
-            z.LuErosion[Y, l] += z.ErosWashoff[l, i]
-            z.LuSedYield[Y, l] = z.LuErosion[Y, l] * z.SedDelivRatio
+            z.LuErosion[Y][l] += z.ErosWashoff[l][i]
+            z.LuSedYield[Y][l] = z.LuErosion[Y][l] * z.SedDelivRatio
 
         # Add in the urban calucation for sediment
         for l in range(z.NRur, z.NLU):
-            z.UrbSedLoad[l, i] += z.LuLoad[Y, l, 2]
+            z.UrbSedLoad[l][i] += z.LuLoad[Y][l][2]
 
     # NUTRIENT FLUXES
     for i in range(12):
@@ -114,58 +114,58 @@ def CalculateLoads(z, Y):
                 z.NConc = z.ManNitr[l]
                 z.PConc = z.ManPhos[l]
 
-            nRunoff = 0.1 * z.NConc * z.RurQRunoff[l, i] * z.Area[l]
-            pRunoff = 0.1 * z.PConc * z.RurQRunoff[l, i] * z.Area[l]
+            nRunoff = 0.1 * z.NConc * z.RurQRunoff[l][i] * z.Area[l]
+            pRunoff = 0.1 * z.PConc * z.RurQRunoff[l][i] * z.Area[l]
 
-            z.DisNitr[Y, i] += nRunoff
-            z.DisPhos[Y, i] += pRunoff
-            z.LuTotNitr[Y, l] += nRunoff
-            z.LuTotPhos[Y, l] += pRunoff
-            z.LuDisNitr[Y, l] += nRunoff
-            z.LuDisPhos[Y, l] += pRunoff
+            z.DisNitr[Y][i] += nRunoff
+            z.DisPhos[Y][i] += pRunoff
+            z.LuTotNitr[Y][l] += nRunoff
+            z.LuTotPhos[Y][l] += pRunoff
+            z.LuDisNitr[Y][l] += nRunoff
+            z.LuDisPhos[Y][l] += pRunoff
 
             # ADD SOLID RURAL NUTRIENTS
-            z.LuTotNitr[Y, l] += 0.001 * z.SedDelivRatio * z.ErosWashoff[l, i] * z.SedNitr
-            z.LuTotPhos[Y, l] += 0.001 * z.SedDelivRatio * z.ErosWashoff[l, i] * z.SedPhos
+            z.LuTotNitr[Y][l] += 0.001 * z.SedDelivRatio * z.ErosWashoff[l][i] * z.SedNitr
+            z.LuTotPhos[Y][l] += 0.001 * z.SedDelivRatio * z.ErosWashoff[l][i] * z.SedPhos
 
-        z.TotNitr[Y, i] = z.DisNitr[Y, i] + 0.001 * z.SedNitr * z.SedYield[Y, i]
-        z.TotPhos[Y, i] = z.DisPhos[Y, i] + 0.001 * z.SedPhos * z.SedYield[Y, i]
+        z.TotNitr[Y][i] = z.DisNitr[Y][i] + 0.001 * z.SedNitr * z.SedYield[Y][i]
+        z.TotPhos[Y][i] = z.DisPhos[Y][i] + 0.001 * z.SedPhos * z.SedYield[Y][i]
 
         # SUM TILE DRAIN N, P, AND SEDIMENT
-        z.TileDrainN[Y, i] += ((((z.TileDrain[Y, i] / 100) * z.TotAreaMeters) * 1000) * z.TileNconc) / 1000000
-        z.TileDrainP[Y, i] += ((((z.TileDrain[Y, i] / 100) * z.TotAreaMeters) * 1000) * z.TilePConc) / 1000000
-        z.TileDrainSed[Y, i] += ((((z.TileDrain[Y, i] / 100) * z.TotAreaMeters) * 1000) * z.TileSedConc) / 1000000
+        z.TileDrainN[Y][i] += ((((z.TileDrain[Y][i] / 100) * z.TotAreaMeters) * 1000) * z.TileNconc) / 1000000
+        z.TileDrainP[Y][i] += ((((z.TileDrain[Y][i] / 100) * z.TotAreaMeters) * 1000) * z.TilePConc) / 1000000
+        z.TileDrainSed[Y][i] += ((((z.TileDrain[Y][i] / 100) * z.TotAreaMeters) * 1000) * z.TileSedConc) / 1000000
 
         # ADD URBAN NUTRIENTS
         for l in range(z.NRur, z.NLU):
-            z.LuTotNitr[Y, l] += z.LuLoad[Y, l, 0] / z.NYrs / 2
-            z.LuTotPhos[Y, l] += z.LuLoad[Y, l, 1] / z.NYrs / 2
-            z.LuDisNitr[Y, l] += z.LuDisLoad[Y, l, 1] / z.NYrs / 2
-            z.LuDisPhos[Y, l] += z.LuDisLoad[Y, l, 2] / z.NYrs / 2
-            z.LuSedYield[Y, l] += (z.LuLoad[Y, l, 2] / z.NYrs) / 1000 / 2
+            z.LuTotNitr[Y][l] += z.LuLoad[Y][l][0] / z.NYrs / 2
+            z.LuTotPhos[Y][l] += z.LuLoad[Y][l][1] / z.NYrs / 2
+            z.LuDisNitr[Y][l] += z.LuDisLoad[Y][l][1] / z.NYrs / 2
+            z.LuDisPhos[Y][l] += z.LuDisLoad[Y][l][2] / z.NYrs / 2
+            z.LuSedYield[Y][l] += (z.LuLoad[Y][l][2] / z.NYrs) / 1000 / 2
 
-        z.DisNitr[Y, i] += z.DisLoad[Y, i, 1]
-        z.DisPhos[Y, i] += z.DisLoad[Y, i, 2]
-        z.TotNitr[Y, i] += z.Load[Y, i, 1]
-        z.TotPhos[Y, i] += z.Load[Y, i, 2]
+        z.DisNitr[Y][i] += z.DisLoad[Y][i][1]
+        z.DisPhos[Y][i] += z.DisLoad[Y][i][2]
+        z.TotNitr[Y][i] += z.Load[Y][i][1]
+        z.TotPhos[Y][i] += z.Load[Y][i][2]
 
         # ADD UPLAND N and P LOADS
-        z.UplandN[Y, i] = z.TotNitr[Y, i]
-        z.UplandP[Y, i] = z.TotPhos[Y, i]
+        z.UplandN[Y][i] = z.TotNitr[Y][i]
+        z.UplandP[Y][i] = z.TotPhos[Y][i]
 
         # ADD GROUNDWATER, POINT SOURCES,
-        z.GroundNitr[Y, i] = 0.1 * z.GrNitrConc * z.GroundWatLE[Y, i] * z.AreaTotal
-        z.GroundPhos[Y, i] = 0.1 * z.GrPhosConc * z.GroundWatLE[Y, i] * z.AreaTotal
-        z.DisNitr[Y, i] += z.GroundNitr[Y, i] + z.PointNitr[i]
-        z.DisPhos[Y, i] += z.GroundPhos[Y, i] + z.PointPhos[i]
-        z.TotNitr[Y, i] += z.GroundNitr[Y, i] + z.PointNitr[i]
-        z.TotPhos[Y, i] += z.GroundPhos[Y, i] + z.PointPhos[i]
+        z.GroundNitr[Y][i] = 0.1 * z.GrNitrConc * z.GroundWatLE[Y][i] * z.AreaTotal
+        z.GroundPhos[Y][i] = 0.1 * z.GrPhosConc * z.GroundWatLE[Y][i] * z.AreaTotal
+        z.DisNitr[Y][i] += z.GroundNitr[Y][i] + z.PointNitr[i]
+        z.DisPhos[Y][i] += z.GroundPhos[Y][i] + z.PointPhos[i]
+        z.TotNitr[Y][i] += z.GroundNitr[Y][i] + z.PointNitr[i]
+        z.TotPhos[Y][i] += z.GroundPhos[Y][i] + z.PointPhos[i]
 
         # ADD SEPTIC SYSTEM SOURCES TO MONTHLY DISSOLVED NUTRIENT TOTALS
         if GroundWatLETotal <= 0:
             GroundWatLETotal = 0.0001
 
-        z.MonthNormNitr[i] = AnNormNitr * z.GroundWatLE[Y, i] / GroundWatLETotal
+        z.MonthNormNitr[i] = AnNormNitr * z.GroundWatLE[Y][i] / GroundWatLETotal
 
         z.DisSeptNitr = (z.MonthNormNitr[i]
                          + z.MonthPondNitr[i]
@@ -181,32 +181,32 @@ def CalculateLoads(z, Y):
         z.DisSeptNitr /= 1000 * 0.59 * 0.66
         z.DisSeptPhos /= 1000
 
-        z.DisNitr[Y, i] += z.DisSeptNitr
-        z.DisPhos[Y, i] += z.DisSeptPhos
-        z.TotNitr[Y, i] += z.DisSeptNitr
-        z.TotPhos[Y, i] += z.DisSeptPhos
-        z.SepticN[Y, i] += z.DisSeptNitr
-        z.SepticP[Y, i] += z.DisSeptPhos
+        z.DisNitr[Y][i] += z.DisSeptNitr
+        z.DisPhos[Y][i] += z.DisSeptPhos
+        z.TotNitr[Y][i] += z.DisSeptNitr
+        z.TotPhos[Y][i] += z.DisSeptPhos
+        z.SepticN[Y][i] += z.DisSeptNitr
+        z.SepticP[Y][i] += z.DisSeptPhos
 
         # ANNUAL TOTALS
-        DisNitrTotal += z.DisNitr[Y, i]
-        DisPhosTotal += z.DisPhos[Y, i]
-        TotNitrTotal += z.TotNitr[Y, i]
-        TotPhosTotal += z.TotPhos[Y, i]
+        DisNitrTotal += z.DisNitr[Y][i]
+        DisPhosTotal += z.DisPhos[Y][i]
+        TotNitrTotal += z.TotNitr[Y][i]
+        TotPhosTotal += z.TotPhos[Y][i]
 
         # UPDATE ANNUAL SEPTIC SYSTEM LOADS
         z.SepticNitr[Y] += z.DisSeptNitr
         z.SepticPhos[Y] += z.DisSeptPhos
 
         # Annual pathogen totals
-        AnimalFCTotal += z.AnimalFC[Y, i]
-        WWOrgsTotal += z.WWOrgs[Y, i]
-        SSOrgsTotal += z.SSOrgs[Y, i]
-        UrbOrgsTotal += z.UrbOrgs[Y, i]
-        WildOrgsTotal += z.WildOrgs[Y, i]
-        TotalOrgsTotal += z.TotalOrgs[Y, i]
-        CMStreamTotal += z.CMStream[Y, i]
-        OrgConcTotal += z.OrgConc[Y, i]
+        AnimalFCTotal += z.AnimalFC[Y][i]
+        WWOrgsTotal += z.WWOrgs[Y][i]
+        SSOrgsTotal += z.SSOrgs[Y][i]
+        UrbOrgsTotal += z.UrbOrgs[Y][i]
+        WildOrgsTotal += z.WildOrgs[Y][i]
+        TotalOrgsTotal += z.TotalOrgs[Y][i]
+        CMStreamTotal += z.CMStream[Y][i]
+        OrgConcTotal += z.OrgConc[Y][i]
 
         # CALCULATE THE VOLUMETRIC STREAM Flow
-        z.StreamFlowVol[Y, i] = ((z.StreamFlowLE[Y, i] / 100) * z.TotAreaMeters) / (86400 * z.DaysMonth[Y, i])
+        z.StreamFlowVol[Y][i] = ((z.StreamFlowLE[Y][i] / 100) * z.TotAreaMeters) / (86400 * z.DaysMonth[Y][i])

--- a/gwlfe/PrelimCalculations.py
+++ b/gwlfe/PrelimCalculations.py
@@ -33,16 +33,16 @@ def InitialCalculations(z):
         elif z.Landuse[l] is LandUse.TURFGRASS:
             z.AgAreaTotal += z.Area[l]
 
-        z.NewCN[0, l] = z.CN[l] / (2.334 - 0.01334 * z.CN[l])
-        z.NewCN[2, l] = z.CN[l] / (0.4036 + 0.0059 * z.CN[l])
-        if z.NewCN[2, l] > 100:
-            z.NewCN[2, l] = 100
+        z.NewCN[0][l] = z.CN[l] / (2.334 - 0.01334 * z.CN[l])
+        z.NewCN[2][l] = z.CN[l] / (0.4036 + 0.0059 * z.CN[l])
+        if z.NewCN[2][l] > 100:
+            z.NewCN[2][l] = 100
 
     for l in range(z.NRur, z.NLU):
-        z.CNI[0, l] = z.CNI[1, l] / (2.334 - 0.01334 * z.CNI[1, 1])
-        z.CNI[2, l] = z.CNI[1, l] / (0.4036 + 0.0059 * z.CNI[1, l])
-        z.CNP[0, l] = z.CNP[1, l] / (2.334 - 0.01334 * z.CNP[1, 1])
-        z.CNP[2, l] = z.CNP[1, l] / (0.4036 + 0.0059 * z.CNP[1, l])
+        z.CNI[0][l] = z.CNI[1][l] / (2.334 - 0.01334 * z.CNI[1][1])
+        z.CNI[2][l] = z.CNI[1][l] / (0.4036 + 0.0059 * z.CNI[1][l])
+        z.CNP[0][l] = z.CNP[1][l] / (2.334 - 0.01334 * z.CNP[1][1])
+        z.CNP[2][l] = z.CNP[1][l] / (0.4036 + 0.0059 * z.CNP[1][l])
 
     if z.FilterWidth <= 30:
         z.FilterEff = z.FilterWidth / 30

--- a/gwlfe/ReadGwlfDataFile.py
+++ b/gwlfe/ReadGwlfDataFile.py
@@ -50,8 +50,8 @@ def ReadAllData(z):
     for l in range(z.NRur, z.NLU):
         # Calculate average area-weighted CN for urban areas
         if z.UrbAreaTotal > 0:
-            z.AvCNUrb += ((z.Imper[l] * z.CNI[1, l]
-                          + (1 - z.Imper[l]) * z.CNP[1, l])
+            z.AvCNUrb += ((z.Imper[l] * z.CNI[1][l]
+                          + (1 - z.Imper[l]) * z.CNP[1][l])
                           * z.Area[l] / z.UrbAreaTotal)
 
     # Calculate the average CN and percent urban area

--- a/gwlfe/StreamBank.py
+++ b/gwlfe/StreamBank.py
@@ -20,16 +20,16 @@ def CalculateStreamBankEros(z, Y):
     for i in range(12):
         # CALCULATE ER FACTOR FOR STREAMBANK EROSION
         # TODO: Should LE for this day default to 0 when StreamFlowVol is 0?
-        if z.StreamFlowVol[Y, i] == 0:
-            z.LE[Y, i] = 0
+        if z.StreamFlowVol[Y][i] == 0:
+            z.LE[Y][i] = 0
         else:
-            z.LE[Y, i] = z.SedAFactor * (z.StreamFlowVolAdj * (z.StreamFlowVol[Y, i] ** -1.6))
+            z.LE[Y][i] = z.SedAFactor * (z.StreamFlowVolAdj * (z.StreamFlowVol[Y][i] ** -1.6))
 
-        z.StreamBankEros[Y, i] = z.LE[Y, i] * z.StreamLength * 1500 * 1.5
+        z.StreamBankEros[Y][i] = z.LE[Y][i] * z.StreamLength * 1500 * 1.5
 
         # CALCULATE STREAM ABANK N AND P
-        z.StreamBankN[Y, i] = z.StreamBankEros[Y, i] * (z.SedNitr / 1000000) * z.BankNFrac
-        z.StreamBankP[Y, i] = z.StreamBankEros[Y, i] * (z.SedPhos / 1000000) * z.BankPFrac
+        z.StreamBankN[Y][i] = z.StreamBankEros[Y][i] * (z.SedNitr / 1000000) * z.BankNFrac
+        z.StreamBankP[Y][i] = z.StreamBankEros[Y][i] * (z.SedPhos / 1000000) * z.BankPFrac
 
         # CALCULATIONS FOR STREAM BANK STABILIZATION AND FENCING
         z.SURBBANK = 0
@@ -38,42 +38,42 @@ def CalculateStreamBankEros(z, Y):
         z.FCURBBANK = 0
 
         if z.n42b > 0:
-            z.SEDSTAB = (z.n46c / z.n42b) * z.StreamBankEros[Y, i] * z.n85d
-            z.SURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankEros[Y, i] * z.n85d
+            z.SEDSTAB = (z.n46c / z.n42b) * z.StreamBankEros[Y][i] * z.n85d
+            z.SURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankEros[Y][i] * z.n85d
 
         if z.n42 > 0:
-            z.SEDFEN = (z.n45 / z.n42) * z.StreamBankEros[Y, i] * z.AGSTRM * z.n85
+            z.SEDFEN = (z.n45 / z.n42) * z.StreamBankEros[Y][i] * z.AGSTRM * z.n85
 
-        z.StreamBankEros[Y, i] = z.StreamBankEros[Y, i] - (z.SEDSTAB + z.SEDFEN + z.SURBBANK)
-        if z.StreamBankEros[Y, i] < 0:
-            z.StreamBankEros[Y, i] = 0
+        z.StreamBankEros[Y][i] = z.StreamBankEros[Y][i] - (z.SEDSTAB + z.SEDFEN + z.SURBBANK)
+        if z.StreamBankEros[Y][i] < 0:
+            z.StreamBankEros[Y][i] = 0
 
         if z.n42b > 0:
-            z.NSTAB = (z.n46c / z.n42b) * z.StreamBankN[Y, i] * z.n69c
-            z.NURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankN[Y, i] * z.n69c
+            z.NSTAB = (z.n46c / z.n42b) * z.StreamBankN[Y][i] * z.n69c
+            z.NURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankN[Y][i] * z.n69c
 
         if z.n42 > 0:
-            z.NFEN = (z.n45 / z.n42) * z.StreamBankN[Y, i] * z.AGSTRM * z.n69
+            z.NFEN = (z.n45 / z.n42) * z.StreamBankN[Y][i] * z.AGSTRM * z.n69
 
-        z.StreamBankN[Y, i] = z.StreamBankN[Y, i] - (z.NSTAB + z.NFEN + z.NURBBANK)
-        if z.StreamBankN[Y, i] < 0:
-            z.StreamBankN[Y, i] = 0
+        z.StreamBankN[Y][i] = z.StreamBankN[Y][i] - (z.NSTAB + z.NFEN + z.NURBBANK)
+        if z.StreamBankN[Y][i] < 0:
+            z.StreamBankN[Y][i] = 0
 
         if z.n42b > 0:
-            z.PSTAB = (z.n46c / z.n42b) * z.StreamBankP[Y, i] * z.n77c
-            z.PURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankP[Y, i] * z.n77c
+            z.PSTAB = (z.n46c / z.n42b) * z.StreamBankP[Y][i] * z.n77c
+            z.PURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankP[Y][i] * z.n77c
 
         if z.n42 > 0:
-            z.PFEN = (z.n45 / z.n42) * z.StreamBankP[Y, i] * z.AGSTRM * z.n77
+            z.PFEN = (z.n45 / z.n42) * z.StreamBankP[Y][i] * z.AGSTRM * z.n77
 
-        z.StreamBankP[Y, i] = z.StreamBankP[Y, i] - (z.PSTAB + z.PFEN + z.PURBBANK)
-        if z.StreamBankP[Y, i] < 0:
-            z.StreamBankP[Y, i] = 0
+        z.StreamBankP[Y][i] = z.StreamBankP[Y][i] - (z.PSTAB + z.PFEN + z.PURBBANK)
+        if z.StreamBankP[Y][i] < 0:
+            z.StreamBankP[Y][i] = 0
 
         # CALCULATE ANNUAL STREAMBANK N AND P AND SEDIMENT
-        z.StreamBankN[Y, 0] = z.StreamBankN[Y, 0] + z.StreamBankN[Y, i]
-        z.StreamBankP[Y, 0] = z.StreamBankP[Y, 0] + z.StreamBankP[Y, i]
-        z.StreamBankEros[Y, 0] = z.StreamBankEros[Y, 0] + z.StreamBankEros[Y, i]
+        z.StreamBankN[Y][0] = z.StreamBankN[Y][0] + z.StreamBankN[Y][i]
+        z.StreamBankP[Y][0] = z.StreamBankP[Y][0] + z.StreamBankP[Y][i]
+        z.StreamBankEros[Y][0] = z.StreamBankEros[Y][0] + z.StreamBankEros[Y][i]
 
         # GROUNDWATER N LOADS ARE REDUCED BASED ON SPECIFIC BMPS
         z.GWNRF = 0
@@ -103,35 +103,35 @@ def CalculateStreamBankEros(z, Y):
 
         if z.AreaTotal > 0 and z.n23 > 0 and z.n42 > 0 and z.n42b > 0:
             z.PCTAG = (z.n23 + z.n24) / z.AreaTotal
-            z.GroundNitr[Y, i] -= z.GroundNitr[Y, i] * ((z.n28b / 100) * z.n23) / z.n23 * z.PCTAG * z.n70
-            z.GroundNitr[Y, i] -= z.GroundNitr[Y, i] * (z.n43 / z.n42) * (z.n42 / z.n42b) * z.PCTAG * z.n64
-            z.GroundNitr[Y, i] -= (z.GroundNitr[Y, i] * ((((z.n29 / 100) * z.n23) + ((z.n37 / 100) * z.n24)) / (z.n23 + z.n24))) * z.PCTAG * z.n68
+            z.GroundNitr[Y][i] -= z.GroundNitr[Y][i] * ((z.n28b / 100) * z.n23) / z.n23 * z.PCTAG * z.n70
+            z.GroundNitr[Y][i] -= z.GroundNitr[Y][i] * (z.n43 / z.n42) * (z.n42 / z.n42b) * z.PCTAG * z.n64
+            z.GroundNitr[Y][i] -= (z.GroundNitr[Y][i] * ((((z.n29 / 100) * z.n23) + ((z.n37 / 100) * z.n24)) / (z.n23 + z.n24))) * z.PCTAG * z.n68
 
         # Groundwater P loads are reduced based on extent of nutrient management BMP
         z.RCNMAC = (z.n28b / 100) * z.n23
         z.HPNMAC = (z.n35b / 100) * z.n24
 
-        z.GroundPhos[Y, i] -= (((z.RCNMAC + z.HPNMAC) / z.AreaTotal) * z.GroundPhos[Y, i] * z.n78)
+        z.GroundPhos[Y][i] -= (((z.RCNMAC + z.HPNMAC) / z.AreaTotal) * z.GroundPhos[Y][i] * z.n78)
 
-        z.GroundNitr[Y, 0] += z.GroundNitr[Y, i]
-        z.GroundPhos[Y, 0] += z.GroundPhos[Y, i]
+        z.GroundNitr[Y][0] += z.GroundNitr[Y][i]
+        z.GroundPhos[Y][0] += z.GroundPhos[Y][i]
 
-        z.TileDrain[Y, 0] += z.TileDrain[Y, i]
-        z.TileDrainN[Y, 0] += z.TileDrainN[Y, i]
-        z.TileDrainP[Y, 0] += z.TileDrainP[Y, i]
-        z.TileDrainSed[Y, 0] += z.TileDrainSed[Y, i]
-        z.AnimalN[Y, 0] += z.AnimalN[Y, i]
-        z.AnimalP[Y, 0] += z.AnimalP[Y, i]
+        z.TileDrain[Y][0] += z.TileDrain[Y][i]
+        z.TileDrainN[Y][0] += z.TileDrainN[Y][i]
+        z.TileDrainP[Y][0] += z.TileDrainP[Y][i]
+        z.TileDrainSed[Y][0] += z.TileDrainSed[Y][i]
+        z.AnimalN[Y][0] += z.AnimalN[Y][i]
+        z.AnimalP[Y][0] += z.AnimalP[Y][i]
 
-        z.GRLostBarnN[Y, 0] += z.GRLostBarnN[Y, i]
-        z.GRLostBarnP[Y, 0] += z.GRLostBarnP[Y, i]
-        z.GRLostBarnFC[Y, 0] += z.GRLostBarnFC[Y, i]
-        z.NGLostBarnN[Y, 0] += z.NGLostBarnN[Y, i]
-        z.NGLostBarnP[Y, 0] += z.NGLostBarnP[Y, i]
-        z.NGLostBarnFC[Y, 0] += z.NGLostBarnFC[Y, i]
-        z.NGLostManP[Y, 0] += z.NGLostManP[Y, i]
+        z.GRLostBarnN[Y][0] += z.GRLostBarnN[Y][i]
+        z.GRLostBarnP[Y][0] += z.GRLostBarnP[Y][i]
+        z.GRLostBarnFC[Y][0] += z.GRLostBarnFC[Y][i]
+        z.NGLostBarnN[Y][0] += z.NGLostBarnN[Y][i]
+        z.NGLostBarnP[Y][0] += z.NGLostBarnP[Y][i]
+        z.NGLostBarnFC[Y][0] += z.NGLostBarnFC[Y][i]
+        z.NGLostManP[Y][0] += z.NGLostManP[Y][i]
 
-        z.TotNitr[Y, i] += z.StreamBankN[Y, i] + z.TileDrainN[Y, i] + z.AnimalN[Y, i]
-        z.TotPhos[Y, i] += z.StreamBankP[Y, i] + z.TileDrainP[Y, i] + z.AnimalP[Y, i]
-        z.TotNitr[Y, 0] += z.StreamBankN[Y, i] + z.TileDrainN[Y, i] + z.AnimalN[Y, i]
-        z.TotPhos[Y, 0] += z.StreamBankP[Y, i] + z.TileDrainP[Y, i] + z.AnimalP[Y, i]
+        z.TotNitr[Y][i] += z.StreamBankN[Y][i] + z.TileDrainN[Y][i] + z.AnimalN[Y][i]
+        z.TotPhos[Y][i] += z.StreamBankP[Y][i] + z.TileDrainP[Y][i] + z.AnimalP[Y][i]
+        z.TotNitr[Y][0] += z.StreamBankN[Y][i] + z.TileDrainN[Y][i] + z.AnimalN[Y][i]
+        z.TotPhos[Y][0] += z.StreamBankP[Y][i] + z.TileDrainP[Y][i] + z.AnimalP[Y][i]

--- a/gwlfe/WriteOutputFiles.py
+++ b/gwlfe/WriteOutputFiles.py
@@ -480,101 +480,101 @@ def WriteOutput(z):
         z.n13bdp = 0
 
         for l in range(z.NLU):
-            z.LuRunoff[y, l] = round(z.LuRunoff[y, l])
-            z.LuErosion[y, l] = round(z.LuErosion[y, l])
-            z.LuSedYield[y, l] = round((z.LuSedYield[y, l] * z.RetentFactorSed * (1 - z.AttenTSS)))
-            z.LuDisNitr[y, l] = round((z.LuDisNitr[y, l] * z.RetentFactorN * (1 - z.AttenN)))
-            z.LuTotNitr[y, l] = round((z.LuTotNitr[y, l] * z.RetentFactorN * (1 - z.AttenN)))
-            z.LuDisPhos[y, l] = round((z.LuDisPhos[y, l] * z.RetentFactorP * (1 - z.AttenP)))
-            z.LuTotPhos[y, l] = round((z.LuTotPhos[y, l] * z.RetentFactorP * (1 - z.AttenP)))
+            z.LuRunoff[y][l] = round(z.LuRunoff[y][l])
+            z.LuErosion[y][l] = round(z.LuErosion[y][l])
+            z.LuSedYield[y][l] = round((z.LuSedYield[y][l] * z.RetentFactorSed * (1 - z.AttenTSS)))
+            z.LuDisNitr[y][l] = round((z.LuDisNitr[y][l] * z.RetentFactorN * (1 - z.AttenN)))
+            z.LuTotNitr[y][l] = round((z.LuTotNitr[y][l] * z.RetentFactorN * (1 - z.AttenN)))
+            z.LuDisPhos[y][l] = round((z.LuDisPhos[y][l] * z.RetentFactorP * (1 - z.AttenP)))
+            z.LuTotPhos[y][l] = round((z.LuTotPhos[y][l] * z.RetentFactorP * (1 - z.AttenP)))
 
             if z.Landuse[l] is LandUse.HAY_PAST:
-                z.n2 = z.LuSedYield[y, l]
-                z.n6 = z.LuTotNitr[y, l]
-                z.n13 = z.LuTotPhos[y, l]
-                z.n6dn = z.LuDisNitr[y, l]
-                z.n13dp = z.LuDisPhos[y, l]
+                z.n2 = z.LuSedYield[y][l]
+                z.n6 = z.LuTotNitr[y][l]
+                z.n13 = z.LuTotPhos[y][l]
+                z.n6dn = z.LuDisNitr[y][l]
+                z.n13dp = z.LuDisPhos[y][l]
             elif z.Landuse[l] is LandUse.CROPLAND:
-                z.n1 = z.LuSedYield[y, l]
-                z.n5 = z.LuTotNitr[y, l]
-                z.n12 = z.LuTotPhos[y, l]
-                z.n5dn = z.LuDisNitr[y, l]
-                z.n12dp = z.LuDisPhos[y, l]
+                z.n1 = z.LuSedYield[y][l]
+                z.n5 = z.LuTotNitr[y][l]
+                z.n12 = z.LuTotPhos[y][l]
+                z.n5dn = z.LuDisNitr[y][l]
+                z.n12dp = z.LuDisPhos[y][l]
             elif z.Landuse[l] is LandUse.UNPAVED_ROAD:
-                z.n2d = z.LuSedYield[y, l]
-                z.n6d = z.LuTotNitr[y, l]
-                z.n13d = z.LuTotPhos[y, l]
-                z.n6ddn = z.LuDisNitr[y, l]
-                z.n13ddp = z.LuDisPhos[y, l]
+                z.n2d = z.LuSedYield[y][l]
+                z.n6d = z.LuTotNitr[y][l]
+                z.n13d = z.LuTotPhos[y][l]
+                z.n6ddn = z.LuDisNitr[y][l]
+                z.n13ddp = z.LuDisPhos[y][l]
             elif z.Landuse[l] is LandUse.TURFGRASS:
-                z.n2t = z.LuSedYield[y, l]
-                z.n6t = z.LuTotNitr[y, l]
-                z.n13t = z.LuTotPhos[y, l]
+                z.n2t = z.LuSedYield[y][l]
+                z.n6t = z.LuTotNitr[y][l]
+                z.n13t = z.LuTotPhos[y][l]
             else:
-                AvOtherLuSed = AvOtherLuSed + z.LuSedYield[y, l]
-                AvOtherLuNitr = AvOtherLuNitr + z.LuTotNitr[y, l]
-                AvOtherLuPhos = AvOtherLuPhos + z.LuTotPhos[y, l]
+                AvOtherLuSed = AvOtherLuSed + z.LuSedYield[y][l]
+                AvOtherLuNitr = AvOtherLuNitr + z.LuTotNitr[y][l]
+                AvOtherLuPhos = AvOtherLuPhos + z.LuTotPhos[y][l]
 
             if z.Landuse[l] in [LandUse.LD_MIXED, LandUse.LD_RESIDENTIAL]:
-                z.n2c = z.n2c + z.LuSedYield[y, l]
-                z.n6c = z.n6c + z.LuTotNitr[y, l]
-                z.n13c = z.n13c + z.LuTotPhos[y, l]
-                z.n6cdn = z.n6cdn + z.LuDisNitr[y, l]
-                z.n13cdp = z.n13cdp + z.LuDisPhos[y, l]
+                z.n2c = z.n2c + z.LuSedYield[y][l]
+                z.n6c = z.n6c + z.LuTotNitr[y][l]
+                z.n13c = z.n13c + z.LuTotPhos[y][l]
+                z.n6cdn = z.n6cdn + z.LuDisNitr[y][l]
+                z.n13cdp = z.n13cdp + z.LuDisPhos[y][l]
             elif z.Landuse[l] in [LandUse.MD_MIXED, LandUse.HD_MIXED,
                                   LandUse.MD_RESIDENTIAL, LandUse.HD_RESIDENTIAL]:
-                z.n2b = z.n2b + z.LuSedYield[y, l]
-                z.n6b = z.n6b + z.LuTotNitr[y, l]
-                z.n13b = z.n13b + z.LuTotPhos[y, l]
-                z.n6bdn = z.n6bdn + z.LuDisNitr[y, l]
-                z.n13bdp = z.n13bdp + z.LuDisPhos[y, l]
+                z.n2b = z.n2b + z.LuSedYield[y][l]
+                z.n6b = z.n6b + z.LuTotNitr[y][l]
+                z.n13b = z.n13b + z.LuTotPhos[y][l]
+                z.n6bdn = z.n6bdn + z.LuDisNitr[y][l]
+                z.n13bdp = z.n13bdp + z.LuDisPhos[y][l]
 
         # Convert animal loads into English units
-        z.GRLBN = z.GRLostBarnN[y, 0]
-        z.NGLBN = z.NGLostBarnN[y, 0]
-        z.GRLBP = z.GRLostBarnP[y, 0]
-        z.NGLBP = z.NGLostBarnP[y, 0]
-        z.NGLManP = z.NGLostManP[y, 0]
+        z.GRLBN = z.GRLostBarnN[y][0]
+        z.NGLBN = z.NGLostBarnN[y][0]
+        z.GRLBP = z.GRLostBarnP[y][0]
+        z.NGLBP = z.NGLostBarnP[y][0]
+        z.NGLManP = z.NGLostManP[y][0]
 
         # Get the fecal coliform values
-        z.NGLBFC = z.NGLostBarnFC[y, 0]
-        z.GRLBFC = z.GRLostBarnFC[y, 0]
+        z.NGLBFC = z.NGLostBarnFC[y][0]
+        z.GRLBFC = z.GRLostBarnFC[y][0]
         z.GRSFC = z.AvGRStreamFC
         z.GRSN = z.AvGRStreamN
         z.GRSP = z.AvGRStreamP
 
         # Get the initial pathogen loads
-        z.n139 = z.AnimalFC[y, 0]
-        z.n140 = z.WWOrgs[y, 0]
-        z.n146 = z.WWOrgs[y, 0]
-        z.n141 = z.SSOrgs[y, 0]
-        z.n147 = z.SSOrgs[y, 0]
-        z.n142 = z.UrbOrgs[y, 0]
-        z.n143 = z.WildOrgs[y, 0]
-        z.n149 = z.WildOrgs[y, 0]
+        z.n139 = z.AnimalFC[y][0]
+        z.n140 = z.WWOrgs[y][0]
+        z.n146 = z.WWOrgs[y][0]
+        z.n141 = z.SSOrgs[y][0]
+        z.n147 = z.SSOrgs[y][0]
+        z.n142 = z.UrbOrgs[y][0]
+        z.n143 = z.WildOrgs[y][0]
+        z.n149 = z.WildOrgs[y][0]
 
         # Initial pathogen total load
         z.n144 = z.n139 + z.n140 + z.n141 + z.n142 + z.n143
 
         # FARM ANIMAL LOADS
-        n7b = z.AnimalN[y, 0]
-        n14b = z.AnimalN[y, 0]
+        n7b = z.AnimalN[y][0]
+        n14b = z.AnimalN[y][0]
 
         # CONVERT AVERAGE STREAM BANK ERIOSION, N AND P TO ENGLISH UNITS
-        z.n4 = round((z.StreamBankEros[y, 0] * z.RetentFactorSed * (1 - z.AttenTSS) * SedConvert))
-        z.n8 = round((z.StreamBankN[y, 0] * NPConvert * z.RetentFactorN * (1 - z.AttenN)))
-        z.n15 = round((z.StreamBankP[y, 0] * NPConvert * z.RetentFactorP * (1 - z.AttenP)))
+        z.n4 = round((z.StreamBankEros[y][0] * z.RetentFactorSed * (1 - z.AttenTSS) * SedConvert))
+        z.n8 = round((z.StreamBankN[y][0] * NPConvert * z.RetentFactorN * (1 - z.AttenN)))
+        z.n15 = round((z.StreamBankP[y][0] * NPConvert * z.RetentFactorP * (1 - z.AttenP)))
 
         # PERFORM LOAD REDUCTIONS BASED ON BMPS IN SCENARIO FILE
         LoadReductions.AdjustScnLoads(z)
 
         # CONVERT AVERAGE STREAM BANK ERIOSION, N AND P TO ENGLISH UNITS
-        z.StreamBankEros[y, 0] = z.n4
-        z.StreamBankN[y, 0] = z.n8
-        z.StreamBankP[y, 0] = z.n15
+        z.StreamBankEros[y][0] = z.n4
+        z.StreamBankN[y][0] = z.n8
+        z.StreamBankP[y][0] = z.n15
 
-        z.AnimalFC[y, 0] = z.n145
-        z.UrbOrgs[y, 0] = z.n148
+        z.AnimalFC[y][0] = z.n145
+        z.UrbOrgs[y][0] = z.n148
 
         # Get the FC reduction for monthly loads
         UrbanFCFrac = 0
@@ -586,16 +586,16 @@ def WriteOutput(z):
             UrbanFCFrac = z.n148 / z.n142
 
         for i in range(12):
-            z.AnimalFC[y, 0] = z.AnimalFC[y, 0] * FarmFCFrac
-            z.UrbOrgs[y, 0] = z.UrbOrgs[y, 0] * UrbanFCFrac
+            z.AnimalFC[y][0] = z.AnimalFC[y][0] * FarmFCFrac
+            z.UrbOrgs[y][0] = z.UrbOrgs[y][0] * UrbanFCFrac
 
         # Reduced total pathogen loads
         n150 = z.n145 + z.n146 + z.n147 + z.n148 + z.n149
-        z.TotalOrgs[y, 0] = n150
+        z.TotalOrgs[y][0] = n150
 
         # FARM ANIMAL LOADS
-        z.AnimalN[y, 0] = n7b
-        z.AnimalN[y, 0] = n14b
+        z.AnimalN[y][0] = n7b
+        z.AnimalN[y][0] = n14b
 
         # FOR ALL LAND USES
         z.TotDisNitr = 0
@@ -606,66 +606,66 @@ def WriteOutput(z):
 
         for l in range(z.NLU):
             if z.Landuse[l] is LandUse.HAY_PAST:
-                z.LuSedYield[y, l] = z.n2
-                z.LuTotNitr[y, l] = z.n6
-                z.LuTotPhos[y, l] = z.n13
-                z.LuDisNitr[y, l] = z.n6dn
-                z.LuDisPhos[y, l] = z.n13dp
+                z.LuSedYield[y][l] = z.n2
+                z.LuTotNitr[y][l] = z.n6
+                z.LuTotPhos[y][l] = z.n13
+                z.LuDisNitr[y][l] = z.n6dn
+                z.LuDisPhos[y][l] = z.n13dp
 
-                if z.LuDisNitr[y, l] > z.LuTotNitr[y, l]:
-                    z.LuDisNitr[y, l] = z.LuTotNitr[y, l]
-                if z.LuDisPhos[y, l] > z.LuTotPhos[y, l]:
-                    z.LuDisPhos[y, l] = z.LuTotPhos[y, l]
+                if z.LuDisNitr[y][l] > z.LuTotNitr[y][l]:
+                    z.LuDisNitr[y][l] = z.LuTotNitr[y][l]
+                if z.LuDisPhos[y][l] > z.LuTotPhos[y][l]:
+                    z.LuDisPhos[y][l] = z.LuTotPhos[y][l]
             elif z.Landuse[l] is LandUse.CROPLAND:
-                if z.LuDisNitr[y, l] > 0:
-                    z.LuDisNitr[y, l] = z.LuDisNitr[y, l] * z.n5 / z.LuTotNitr[y, l]
-                if z.LuDisPhos[y, l] > 0:
-                    z.LuDisPhos[y, l] = z.LuDisPhos[y, l] * z.n12 / z.LuTotPhos[y, l]
+                if z.LuDisNitr[y][l] > 0:
+                    z.LuDisNitr[y][l] = z.LuDisNitr[y][l] * z.n5 / z.LuTotNitr[y][l]
+                if z.LuDisPhos[y][l] > 0:
+                    z.LuDisPhos[y][l] = z.LuDisPhos[y][l] * z.n12 / z.LuTotPhos[y][l]
 
-                z.LuSedYield[y, l] = z.n1
-                z.LuTotNitr[y, l] = z.n5
-                z.LuTotPhos[y, l] = z.n12
-                z.LuDisNitr[y, l] = z.n5dn
-                z.LuDisPhos[y, l] = z.n12dp
+                z.LuSedYield[y][l] = z.n1
+                z.LuTotNitr[y][l] = z.n5
+                z.LuTotPhos[y][l] = z.n12
+                z.LuDisNitr[y][l] = z.n5dn
+                z.LuDisPhos[y][l] = z.n12dp
             elif z.Landuse[l] is LandUse.UNPAVED_ROAD:
-                z.LuSedYield[y, l] = z.n2d
-                z.LuTotNitr[y, l] = z.n6d
-                z.LuTotPhos[y, l] = z.n13d
-                z.LuDisNitr[y, l] = z.n6ddn
-                z.LuDisPhos[y, l] = z.n13ddp
+                z.LuSedYield[y][l] = z.n2d
+                z.LuTotNitr[y][l] = z.n6d
+                z.LuTotPhos[y][l] = z.n13d
+                z.LuDisNitr[y][l] = z.n6ddn
+                z.LuDisPhos[y][l] = z.n13ddp
 
-                if z.LuDisNitr[y, l] > z.LuTotNitr[y, l]:
-                    z.LuDisNitr[y, l] = z.LuTotNitr[y, l]
-                if z.LuDisPhos[y, l] > z.LuTotPhos[y, l]:
-                    z.LuDisPhos[y, l] = z.LuTotPhos[y, l]
+                if z.LuDisNitr[y][l] > z.LuTotNitr[y][l]:
+                    z.LuDisNitr[y][l] = z.LuTotNitr[y][l]
+                if z.LuDisPhos[y][l] > z.LuTotPhos[y][l]:
+                    z.LuDisPhos[y][l] = z.LuTotPhos[y][l]
 
             if z.n24b > 0 and z.Landuse[l] in [LandUse.LD_MIXED, LandUse.LD_RESIDENTIAL]:
-                z.LuSedYield[y, l] = z.n2c * z.Area[l] / z.n24b
-                z.LuTotNitr[y, l] = z.n6c * z.Area[l] / z.n24b
-                z.LuTotPhos[y, l] = z.n13c * z.Area[l] / z.n24b
-                z.LuDisNitr[y, l] = z.n6cdn * z.Area[l] / z.n24b
-                z.LuDisPhos[y, l] = z.n13cdp * z.Area[l] / z.n24b
+                z.LuSedYield[y][l] = z.n2c * z.Area[l] / z.n24b
+                z.LuTotNitr[y][l] = z.n6c * z.Area[l] / z.n24b
+                z.LuTotPhos[y][l] = z.n13c * z.Area[l] / z.n24b
+                z.LuDisNitr[y][l] = z.n6cdn * z.Area[l] / z.n24b
+                z.LuDisPhos[y][l] = z.n13cdp * z.Area[l] / z.n24b
 
-                if z.LuDisNitr[y, l] > z.LuTotNitr[y, l]:
-                    z.LuDisNitr[y, l] = z.LuTotNitr[y, l]
-                if z.LuDisPhos[y, l] > z.LuTotPhos[y, l]:
-                    z.LuDisPhos[y, l] = z.LuTotPhos[y, l]
+                if z.LuDisNitr[y][l] > z.LuTotNitr[y][l]:
+                    z.LuDisNitr[y][l] = z.LuTotNitr[y][l]
+                if z.LuDisPhos[y][l] > z.LuTotPhos[y][l]:
+                    z.LuDisPhos[y][l] = z.LuTotPhos[y][l]
             elif z.n23b > 0 and z.Landuse[l] in [LandUse.MD_MIXED, LandUse.HD_MIXED,
                                                  LandUse.MD_RESIDENTIAL, LandUse.HD_RESIDENTIAL]:
-                z.LuSedYield[y, l] = z.n2b * z.Area[l] / z.n23b
-                z.LuTotNitr[y, l] = z.n6b * z.Area[l] / z.n23b
-                z.LuTotPhos[y, l] = z.n13b * z.Area[l] / z.n23b
-                z.LuDisNitr[y, l] = z.n6bdn * z.Area[l] / z.n23b
-                z.LuDisPhos[y, l] = z.n13bdp * z.Area[l] / z.n23b
+                z.LuSedYield[y][l] = z.n2b * z.Area[l] / z.n23b
+                z.LuTotNitr[y][l] = z.n6b * z.Area[l] / z.n23b
+                z.LuTotPhos[y][l] = z.n13b * z.Area[l] / z.n23b
+                z.LuDisNitr[y][l] = z.n6bdn * z.Area[l] / z.n23b
+                z.LuDisPhos[y][l] = z.n13bdp * z.Area[l] / z.n23b
 
-                if z.LuDisNitr[y, l] > z.LuTotNitr[y, l]:
-                    z.LuDisNitr[y, l] = z.LuTotNitr[y, l]
-                if z.LuDisPhos[y, l] > z.LuTotPhos[y, l]:
-                    z.LuDisPhos[y, l] = z.LuTotPhos[y, l]
-            if z.LuDisNitr[y, l] > z.LuTotNitr[y, l]:
-                z.LuDisNitr[y, l] = z.LuTotNitr[y, l]
-            if z.LuDisPhos[y, l] > z.LuTotPhos[y, l]:
-                z.LuDisPhos[y, l] = z.LuTotPhos[y, l]
+                if z.LuDisNitr[y][l] > z.LuTotNitr[y][l]:
+                    z.LuDisNitr[y][l] = z.LuTotNitr[y][l]
+                if z.LuDisPhos[y][l] > z.LuTotPhos[y][l]:
+                    z.LuDisPhos[y][l] = z.LuTotPhos[y][l]
+            if z.LuDisNitr[y][l] > z.LuTotNitr[y][l]:
+                z.LuDisNitr[y][l] = z.LuTotNitr[y][l]
+            if z.LuDisPhos[y][l] > z.LuTotPhos[y][l]:
+                z.LuDisPhos[y][l] = z.LuTotPhos[y][l]
 
     # WRITE THE RESULTS FILES INTO THE OUTPUT DIRECTORY IN METRIC UNITS
     # TODO: Skipping section that prepares and writes AnnualFile and AnnCsvFile

--- a/gwlfe/gwlfe.py
+++ b/gwlfe/gwlfe.py
@@ -57,11 +57,11 @@ def run(z):
         # FOR EACH MONTH...
         for i in range(12):
             # DAILY CALCULATIONS
-            for j in range(z.DaysMonth[Y, i]):
-                # DAILYWEATHERANALY TEMP[Y, I, J], PREC[Y, I, J]
+            for j in range(z.DaysMonth[Y][i]):
+                # DAILYWEATHERANALY TEMP[Y][I][J], PREC[Y][I][J]
                 # ***** BEGIN WEATHER DATA ANALYSIS *****
-                z.DailyTemp = z.Temp[Y, i, j]
-                z.DailyPrec = z.Prec[Y, i, j]
+                z.DailyTemp = z.Temp[Y][i][j]
+                z.DailyPrec = z.Prec[Y][i][j]
                 z.Melt = 0
                 z.Rain = 0
                 z.Water = 0
@@ -93,17 +93,17 @@ def run(z):
                         # A DEGREE-DAY INITSNOW MELT, BUT NO MORE THAN EXISTED
                         # INITSNOW
                         z.Melt = 0.45 * z.DailyTemp
-                        z.MeltPest[Y, i, j] = z.Melt
+                        z.MeltPest[Y][i][j] = z.Melt
                         if z.Melt > z.InitSnow:
                             z.Melt = z.InitSnow
-                            z.MeltPest[Y, i, j] = z.InitSnow
+                            z.MeltPest[Y][i][j] = z.InitSnow
                         z.InitSnow = z.InitSnow - z.Melt
                     else:
-                        z.MeltPest[Y, i, j] = 0
+                        z.MeltPest[Y][i][j] = 0
 
                     # AVAILABLE WATER CALCULATION
                     z.Water = z.Rain + z.Melt
-                    z.DailyWater[Y, i, j] = z.Water
+                    z.DailyWater[Y][i][j] = z.Water
 
                     # Compute erosivity when erosion occurs, i.e., with rain and no InitSnow left
                     if z.Rain > 0 and z.InitSnow < 0.001:
@@ -115,12 +115,12 @@ def run(z):
                         CalcCnErosRunoffSed.CalcCN(z, i, Y, j)
 
                 # DAILY CN
-                z.DailyCN[Y, i, j] = z.CNum
+                z.DailyCN[Y][i][j] = z.CNum
 
                 # UPDATE ANTECEDENT RAIN+MELT CONDITION
                 # Subtract AMC5 by the sum of AntMoist (day 5) and Water
                 z.AMC5 = z.AMC5 - z.AntMoist[4] + z.Water
-                z.DailyAMC5[Y, i, j] = z.AMC5
+                z.DailyAMC5[Y][i][j] = z.AMC5
 
                 # Shift AntMoist values to the right.
                 z.AntMoist[4] = z.AntMoist[3]
@@ -142,7 +142,7 @@ def run(z):
                         z.ET = z.KV[i] * z.PotenET * z.PcntET[i]
 
                 # Daily ET calculation
-                z.DailyET[Y, i, j] = z.ET
+                z.DailyET[Y][i][j] = z.ET
 
                 # ***** END WEATHER DATA ANALYSIS *****
 
@@ -169,12 +169,12 @@ def run(z):
                 # Obtain the Percolation, adjust precip and UnsatStor values
                 if z.UnsatStor > z.MaxWaterCap:
                     z.Percolation = z.UnsatStor - z.MaxWaterCap
-                    z.Perc[Y, i, j] = z.UnsatStor - z.MaxWaterCap
+                    z.Perc[Y][i][j] = z.UnsatStor - z.MaxWaterCap
                     z.UnsatStor = z.UnsatStor - z.Percolation
                 else:
                     z.Percolation = 0
-                    z.Perc[Y, i, j] = 0
-                z.PercCm[Y, i, j] = z.Percolation / 100
+                    z.Perc[Y][i][j] = 0
+                z.PercCm[Y][i][j] = z.Percolation / 100
 
                 # CALCULATE STORAGE IN SATURATED ZONES AND GROUNDWATER
                 # DISCHARGE
@@ -182,20 +182,20 @@ def run(z):
                 if z.SatStor < 0:
                     z.SatStor = 0
                 z.Flow = z.QTotal + z.GrFlow
-                z.DailyFlow[Y, i, j] = z.DayRunoff[Y, i, j] + z.GrFlow
+                z.DailyFlow[Y][i][j] = z.DayRunoff[Y][i][j] + z.GrFlow
 
-                z.DailyFlowGPM[Y, i, j] = z.Flow * 0.00183528 * z.TotAreaMeters
-                z.DailyGrFlow[Y, i, j] = z.GrFlow  # (for daily load calculations)
+                z.DailyFlowGPM[Y][i][j] = z.Flow * 0.00183528 * z.TotAreaMeters
+                z.DailyGrFlow[Y][i][j] = z.GrFlow  # (for daily load calculations)
 
                 # MONTHLY FLOW
-                z.MonthFlow[Y, i] = z.MonthFlow[Y, i] + z.DailyFlow[Y, i, j]
+                z.MonthFlow[Y][i] = z.MonthFlow[Y][i] + z.DailyFlow[Y][i][j]
 
                 # CALCULATE TOTALS
-                z.Precipitation[Y, i] = z.Precipitation[Y, i] + z.Prec[Y, i, j]
-                z.Evapotrans[Y, i] = z.Evapotrans[Y, i] + z.ET
+                z.Precipitation[Y][i] = z.Precipitation[Y][i] + z.Prec[Y][i][j]
+                z.Evapotrans[Y][i] = z.Evapotrans[Y][i] + z.ET
 
-                z.StreamFlow[Y, i] = z.StreamFlow[Y, i] + z.Flow
-                z.GroundWatLE[Y, i] = z.GroundWatLE[Y, i] + z.GrFlow
+                z.StreamFlow[Y][i] = z.StreamFlow[Y][i] + z.Flow
+                z.GroundWatLE[Y][i] = z.GroundWatLE[Y][i] + z.GrFlow
 
                 grow_factor = GrowFlag.intval(z.Grow[i])
 
@@ -206,7 +206,7 @@ def run(z):
                                   (z.PhosSepticLoad - z.PhosPlantUptake * grow_factor))
 
                 # UPDATE MASS BALANCE ON PONDED EFFLUENT
-                if z.Temp[Y, i, j] <= 0 or z.InitSnow > 0:
+                if z.Temp[Y][i][j] <= 0 or z.InitSnow > 0:
 
                     # ALL INPUTS GO TO FROZEN STORAGE
                     z.FrozenPondNitr = z.FrozenPondNitr + z.PondNitrLoad
@@ -241,34 +241,34 @@ def run(z):
                 z.MonthDischargePhos[i] = z.MonthDischargePhos[i] + z.PhosSepticLoad
 
             # CALCULATE WITHDRAWAL AND POINT SOURCE FLOW VALUES
-            z.Withdrawal[Y, i] = (z.Withdrawal[Y, i] + z.StreamWithdrawal[i] +
+            z.Withdrawal[Y][i] = (z.Withdrawal[Y][i] + z.StreamWithdrawal[i] +
                                   z.GroundWithdrawal[i])
-            z.PtSrcFlow[Y, i] = z.PtSrcFlow[Y, i] + z.PointFlow[i]
+            z.PtSrcFlow[Y][i] = z.PtSrcFlow[Y][i] + z.PointFlow[i]
 
             # CALCULATE THE SURFACE RUNOFF PORTION OF TILE DRAINAGE
-            z.TileDrainRO[Y, i] = (z.TileDrainRO[Y, i] + [z.AgRunoff[Y, i] *
+            z.TileDrainRO[Y][i] = (z.TileDrainRO[Y][i] + [z.AgRunoff[Y][i] *
                                    z.TileDrainDensity])
 
             # CALCULATE SUBSURFACE PORTION OF TILE DRAINAGE
-            z.GwAgLE[Y, i] = (z.GwAgLE[Y, i] + (z.GroundWatLE[Y, i] *
+            z.GwAgLE[Y][i] = (z.GwAgLE[Y][i] + (z.GroundWatLE[Y][i] *
                               (z.AgAreaTotal / z.AreaTotal)))
-            z.TileDrainGW[Y, i] = (z.TileDrainGW[Y, i] + [z.GwAgLE[Y, i] *
+            z.TileDrainGW[Y][i] = (z.TileDrainGW[Y][i] + [z.GwAgLE[Y][i] *
                                    z.TileDrainDensity])
 
             # ADD THE TWO COMPONENTS OF TILE DRAINAGE FLOW
-            z.TileDrain[Y, i] = (z.TileDrain[Y, i] + z.TileDrainRO[Y, i] +
-                                 z.TileDrainGW[Y, i])
+            z.TileDrain[Y][i] = (z.TileDrain[Y][i] + z.TileDrainRO[Y][i] +
+                                 z.TileDrainGW[Y][i])
 
             # ADJUST THE GROUNDWATER FLOW
-            z.GroundWatLE[Y, i] = z.GroundWatLE[Y, i] - z.TileDrainGW[Y, i]
-            if z.GroundWatLE[Y, i] < 0:
-                z.GroundWatLE[Y, i] = 0
+            z.GroundWatLE[Y][i] = z.GroundWatLE[Y][i] - z.TileDrainGW[Y][i]
+            if z.GroundWatLE[Y][i] < 0:
+                z.GroundWatLE[Y][i] = 0
 
             # ADJUST THE SURFACE RUNOFF
-            z.Runoff[Y, i] = z.Runoff[Y, i] - z.TileDrainRO[Y, i]
+            z.Runoff[Y][i] = z.Runoff[Y][i] - z.TileDrainRO[Y][i]
 
-            if z.Runoff[Y, i] < 0:
-                z.Runoff[Y, i] = 0
+            if z.Runoff[Y][i] < 0:
+                z.Runoff[Y][i] = 0
 
         # CALCULATE ANIMAL FEEDING OPERATIONS OUTPUT
         AFOS.AnimalOperations(z, Y)

--- a/gwlfe/parser.py
+++ b/gwlfe/parser.py
@@ -517,8 +517,8 @@ class GmsReader(object):
             z.Landuse[i] = self.next(LandUse.parse)  # Urban Land Use Category
             z.Area[i] = self.next(float)  # Area (Ha)
             z.Imper[i] = self.next(float)  # Impervious Surface %
-            z.CNI[1, i] = self.next(float)  # Curve Number(Impervious Surfaces)
-            z.CNP[1, i] = self.next(float)  # Curve Number(Pervious Surfaces)
+            z.CNI[1][i] = self.next(float)  # Curve Number(Impervious Surfaces)
+            z.CNP[1][i] = self.next(float)  # Curve Number(Pervious Surfaces)
             z.TotSusSolids[i] = self.next(float)  # Total Suspended Solids Factor
             self.next(EOL)
 


### PR DESCRIPTION
## Overview

The comma seperated notation for accessing multi-dimensional arrays works for numpy arrays, and was kept for consistency with the original Visual Basic source. However, the multi-bracket notation works with both numpy and regular Python arrays, and thus is more compatible.

To ease serialization, we may switch Model My Watershed to not create numpy arrays. Thus, this fix will allow supporting regular Python arrays as well.

## Testing Instructions

Ensure tests pass. Ensure there are no missed cases.

## Notes

Does this affect performance in any way? If so, we will have to think of a way to ensure that Python arrays are converted to numpy before handing off to the GWLF-E.