### PR TITLE
Wire up dependencies in setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,15 @@ env/
 *,cover
 htmlcov/
 test/compare.csv
+
+build/
+dist/
+*.egg-info/
+*.egg
+*.py[cod]
+__pycache__/
+*.so
+*~
+.tox
+.cache
+.eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: python
-python:
-- '2.7'
-install: pip install -r requirements.txt --use-mirrors
-script: python setup.py test
+
+sudo: false
+
+env:
+  - TOXENV=py27
+
+install: pip install tox --use-mirrors
+
+script: tox
+
 deploy:
   provider: pypi
   user: azavea

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 include DESCRIPTION.rst
+include *.md
+include *.py
+include LICENSE
 
 recursive-include test *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-argparse==1.2.1
-coverage==4.0.3
-nose==1.3.4
-numpy==1.11.0
-wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ with open(path.join(path.abspath(path.dirname(__file__)),
           'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-tests_require = ['nose >= 1.3.4']
+tests_require = [
+    'nose == 1.3.4',
+    'coverage == 4.0.3'
+]
 
 setup(
     name='gwlf-e',
@@ -21,6 +24,7 @@ setup(
     long_description=long_description,
     url='https://github.com/WikiWatershed/gwlf-e',
     author='Azavea Inc.',
+    author_email='systems@azavea.com',
     license='Apache License 2.0',
     classifiers=[
         'Development Status :: 1 - Planning',
@@ -32,7 +36,9 @@ setup(
     ],
     keywords='gwlf-e watershed hydrology',
     packages=find_packages(exclude=['tests']),
-    install_requires=[],
+    install_requires=[
+        'numpy == 1.11.0'
+    ],
     extras_require={
         'dev': [],
         'test': tests_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = py27
+
+[testenv]
+basepython =
+    py27: python2.7
+deps =
+    check-manifest
+    readme_renderer
+    pytest-runner
+    pytest
+commands =
+    check-manifest --ignore tox.ini,test*
+    python setup.py check -m -r -s
+    python setup.py test
+
+[flake8]
+exclude = .tox,*.egg,build,data
+select = E,W,F


### PR DESCRIPTION
Specify runtime and test dependencies are outlined in `setup.py` so that `setuptools` can ensure they're installed prior to the installation of `gwlf-e`.

In addition, move test setup and execution under `tox` to help with packaging and dependency isolation.

---

**Testing**

Most of the testing should be handled by Travis CI since the installation of project dependencies has been removed from its configuration, but it might not hurt to execute the test suite locally to ensure that it passes:

```bash
$ pip install tox
$ tox
```