### PR TITLE
Move default values from parser to datamodel

### DIFF
--- a/gwlfe/datamodel.py
+++ b/gwlfe/datamodel.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from calendar import monthrange
 from decimal import Decimal
 import json
 
@@ -13,6 +14,7 @@ class DataModel(object):
     def __init__(self, data=None):
         self.__dict__.update(self.defaults())
         self.__dict__.update(data or {})
+        self.__dict__.update(self.date_guides())
 
     def defaults(self):
         NLU = 16
@@ -104,6 +106,33 @@ class DataModel(object):
             'CSNAreaSim': 0,
             'CSNDevType': 'None',
         }
+
+    def date_guides(self):
+        model = self.__dict__
+        output = {}
+        if 'WxYrBeg' in model and 'WxYrEnd' in model:
+            begyear = model['WxYrBeg']
+            endyear = model['WxYrEnd']
+            year_range = endyear - begyear + 1
+            month_abbr = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+            if 'DaysMonth' not in model:
+                output['DaysMonth'] = np.zeros((year_range, 12),
+                                               dtype=np.int)
+                for y in range(year_range):
+                    year = begyear + y
+                    for m in range(12):
+                        output['DaysMonth'][y][m] = monthrange(year, m + 1)[1]
+
+            if 'WxMonth' not in model:
+                output['WxMonth'] = [month_abbr
+                                     for y in range(year_range)]
+
+            if 'WxYear' not in model:
+                output['WxYear'] = [[begyear + y] * 12
+                                    for y in range(year_range)]
+        return output
 
     def __str__(self):
         return '<GWLF-E DataModel>'

--- a/gwlfe/datamodel.py
+++ b/gwlfe/datamodel.py
@@ -15,7 +15,95 @@ class DataModel(object):
         self.__dict__.update(data or {})
 
     def defaults(self):
-        return {}
+        NLU = 16
+        NAnimals = 9
+
+        return {
+            'BasinId': 0,
+            'AgSlope3to8': 0,
+            'NumUAs': 0,
+            'UABasinArea': 0,
+
+            # Variables that are passed to PRedICT and are no longer used.
+            'InName': '',
+            'OutName': '',
+            'UnitsFileFlag': 1,
+            'AssessDate': '',
+            'VersionNo': '',
+            'ProjName': '',
+
+            'NLU': NLU,
+            'NAnimals': NAnimals,
+
+            'Landuse': np.zeros(NLU, dtype=object),
+            'Area': np.zeros(NLU),
+            'CN': np.zeros(NLU),
+            'KF': np.zeros(NLU),
+            'LS': np.zeros(NLU),
+            'C': np.zeros(NLU),
+            'P': np.zeros(NLU),
+
+            'NumNormalSys': np.zeros(12, dtype=int),
+            'NumPondSys': np.zeros(12),
+            'NumShortSys': np.zeros(12),
+            'NumDischargeSys': np.zeros(12),
+            'NumSewerSys': np.zeros(12),
+
+            'SEDFEN': 0,
+            'NFEN': 0,
+            'PFEN': 0,
+
+            'n86': 0,
+            'n87': 0,
+            'n88': 0,
+            'n89': 0,
+            'n90': 0,
+            'n91': 0,
+            'n92': 0,
+            'n93': 0,
+            'n94': 0,
+            'n95': 0,
+            'n95b': 0,
+            'n95c': 0,
+            'n95d': 0,
+            'n95e': 0,
+
+            'n96': 0,
+            'n97': 0,
+            'n98': 0,
+            'n99': 0,
+            'n99b': 0,
+            'n99c': 0,
+            'n99d': 0,
+            'n99e': 0,
+            'n100': 0,
+            'n101': 0,
+            'n101b': 0,
+            'n101c': 0,
+            'n101d': 0,
+            'n101e': 0,
+            'n102': 0,
+            'n103a': 0,
+            'n103b': 0,
+            'n103c': 0,
+            'n103d': 0,
+
+            'n104': 0,
+            'n105': 0,
+            'n106': 0,
+            'n106b': 0,
+            'n106c': 0,
+            'n106d': 0,
+            'n107': 0,
+            'n107b': 0,
+            'n107c': 0,
+            'n107d': 0,
+            'n107e': 0,
+
+            'Storm': 0,
+            'CSNAreaSim': 0,
+            'CSNDevType': 'None',
+        }
 
     def __str__(self):
         return '<GWLF-E DataModel>'

--- a/gwlfe/parser.py
+++ b/gwlfe/parser.py
@@ -252,9 +252,6 @@ class GmsReader(object):
 
         z.NLU = z.NRur + z.NUrb
 
-        # This is hard-coded to 9 in the original GWLF-E code.
-        z.NAnimals = 9
-
         # Line 2:
         z.TranVersionNo = self.next(str)  # GWLF-E Version
         z.RecessionCoef = self.next(float)  # Recession Coefficient
@@ -501,14 +498,6 @@ class GmsReader(object):
             self.next(EOL)
 
         # Lines 20 - 29: (for each Rural Land Use Category)
-        z.Landuse = np.zeros(z.NLU, dtype=object)
-        z.Area = np.zeros(z.NLU)
-        z.CN = np.zeros(z.NLU)
-        z.KF = np.zeros(z.NLU)
-        z.LS = np.zeros(z.NLU)
-        z.C = np.zeros(z.NLU)
-        z.P = np.zeros(z.NLU)
-
         for i in range(z.NRur):
             z.Landuse[i] = self.next(LandUse.parse)  # Rural Land Use Category
             z.Area[i] = self.next(float)  # Area (Ha)
@@ -635,12 +624,6 @@ class GmsReader(object):
         self.next(EOL)
 
         # Lines 86 - 97: (Septic System data for each Month)
-        z.NumNormalSys = np.zeros(12)
-        z.NumPondSys = np.zeros(12)
-        z.NumShortSys = np.zeros(12)
-        z.NumDischargeSys = np.zeros(12)
-        z.NumSewerSys = np.zeros(12)
-
         for i in range(12):
             z.NumNormalSys[i] = self.next(int)  # Number of People on Normal Systems
             z.NumPondSys[i] = self.next(int)  # Number of People on Pond Systems

--- a/gwlfe/parser.py
+++ b/gwlfe/parser.py
@@ -1168,7 +1168,7 @@ class GmsReader(object):
 
         # Line 148-156: (For each Animal type)
         z.AnimalName = np.zeros(z.NAnimals, dtype=object)
-        z.NumAnimals = np.zeros(z.NAnimals)
+        z.NumAnimals = np.zeros(z.NAnimals, dtype=int)
         z.GrazingAnimal = np.zeros(z.NAnimals, dtype=object)
         z.AvgAnimalWt = np.zeros(z.NAnimals)
         z.AnimalDailyN = np.zeros(z.NAnimals)
@@ -1268,7 +1268,7 @@ class GmsReader(object):
                 self.next(EOL)
 
                 for day in range(z.DaysMonth[year][month]):
-                    z.Temp[year][month][day] = self.next(int)  # Average Temperature (C)
+                    z.Temp[year][month][day] = self.next(float)  # Average Temperature (C)
                     z.Prec[year][month][day] = self.next(float)  # Precipitation (cm)
                     self.next(EOL)
 


### PR DESCRIPTION
Some default values were moved from the parser to the `DataModel` to
make it easier to run the model against a sparsely populated dict
containing MapShed data.

Depends on #57 
Connects #59 