### PR TITLE
Support 1 Sq Km Urban Area

### DIFF
--- a/gwlfe/PrelimCalculations.py
+++ b/gwlfe/PrelimCalculations.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 def InitialCalculations(z):
     # OBTAIN THE LENGTH OF STREAMS IN AGRICULTURAL AREAS
-    z.AGSTRM = z.AgLength / z.StreamLength
+    z.AGSTRM = z.AgLength / z.StreamLength if z.StreamLength > 0 else 0
 
     # Obtain areas in Ha for Urban, Agricultural and Forested landuse
     for l in range(z.NRur):

--- a/gwlfe/ReadGwlfDataFile.py
+++ b/gwlfe/ReadGwlfDataFile.py
@@ -41,7 +41,8 @@ def ReadAllData(z):
     z.AvCNRur = 0
     for l in range(z.NRur):
         # Calculate average area weighted CN and KF
-        z.AvCNRur += z.CN[l] * z.Area[l] / z.RurAreaTotal
+        z.AvCNRur += (z.CN[l] * z.Area[l] / z.RurAreaTotal) \
+            if z.RurAreaTotal > 0 else 0
 
     # Get the area weighted average CN for urban areas
     z.AvCNUrb = 0

--- a/gwlfe/StreamBank.py
+++ b/gwlfe/StreamBank.py
@@ -31,10 +31,13 @@ def CalculateStreamBankEros(z, Y):
         z.PURBBANK = 0
         z.FCURBBANK = 0
 
+        z.SEDSTAB = 0
+        z.SURBBANK = 0
         if z.n42b > 0:
             z.SEDSTAB = (z.n46c / z.n42b) * z.StreamBankEros[Y][i] * z.n85d
             z.SURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankEros[Y][i] * z.n85d
 
+        z.SEDFEN = 0
         if z.n42 > 0:
             z.SEDFEN = (z.n45 / z.n42) * z.StreamBankEros[Y][i] * z.AGSTRM * z.n85
 
@@ -42,10 +45,13 @@ def CalculateStreamBankEros(z, Y):
         if z.StreamBankEros[Y][i] < 0:
             z.StreamBankEros[Y][i] = 0
 
+        z.NSTAB = 0
+        z.NURBBANK = 0
         if z.n42b > 0:
             z.NSTAB = (z.n46c / z.n42b) * z.StreamBankN[Y][i] * z.n69c
             z.NURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankN[Y][i] * z.n69c
 
+        z.NFEN = 0
         if z.n42 > 0:
             z.NFEN = (z.n45 / z.n42) * z.StreamBankN[Y][i] * z.AGSTRM * z.n69
 
@@ -53,10 +59,13 @@ def CalculateStreamBankEros(z, Y):
         if z.StreamBankN[Y][i] < 0:
             z.StreamBankN[Y][i] = 0
 
+        z.PSTAB = 0
+        z.PURBBANK = 0
         if z.n42b > 0:
             z.PSTAB = (z.n46c / z.n42b) * z.StreamBankP[Y][i] * z.n77c
             z.PURBBANK = (z.UrbBankStab / z.n42b) * z.StreamBankP[Y][i] * z.n77c
 
+        z.PFEN = 0
         if z.n42 > 0:
             z.PFEN = (z.n45 / z.n42) * z.StreamBankP[Y][i] * z.AGSTRM * z.n77
 


### PR DESCRIPTION
## Overview

Previously a GWLF-E run would fail when the GMS file contained no stream data. Technically, that is invalid input since the model can't produce as accurate results without that data. However, to prevent production crashes, we add tolerance to treat streams as 0 in case they are not provided.

## Testing Instructions

Check out this branch. Open MMW and create a project with 1 Sq Km stamp tool in an urban area with no streams. The "Gathering Data" step should succeed, but the "Calculating Results" step should fail. However, now you should be able to export a GMS file from Current Conditions. Alternatively, you may use this prepared file of a similar area: [Urban_SqKm.gms](https://github.com/WikiWatershed/gwlf-e/files/303075/Urban_SqKm.gms.txt) (rename the file to `Urban_SqKm.gms` upon downloading).

Then, run the file through GWLF-E. On `develop`, you should get errors:

```
> python run.py Urban_SqKm.gms 
Running model...
Traceback (most recent call last):
  File "run.py", line 30, in <module>
    main()
  File "run.py", line 25, in main
    result = gwlfe.run(z)
  File "/Users/ttuhinanshu/dev/mmw-gwlfe/gwlfe/gwlfe.py", line 38, in run
    ReadGwlfDataFile.ReadAllData(z)
  File "/Users/ttuhinanshu/dev/mmw-gwlfe/gwlfe/ReadGwlfDataFile.py", line 44, in ReadAllData
    z.AvCNRur += z.CN[l] * z.Area[l] / z.RurAreaTotal
FloatingPointError: invalid value encountered in double_scalars
```

But running on this branch should succeed:

```
> python run.py Urban_SqKm.gms 
Running model...
Model run complete for 30 years of data.
{
    "MeanFlow": 993986.80412083666, 
    "monthly": [
        {
            "AvEvapoTrans": 0.057817123832848379, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 7.9764466666666678, 
            "AvRunoff": 4.3246752761691329, 
            "AvGroundWater": 3.9790302868669145, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 8.303705563036047
        }, 
        {
            "AvEvapoTrans": 0.070255585267511758, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 7.0840600000000009, 
            "AvRunoff": 4.3022742627718173, 
            "AvGroundWater": 3.2590158453389275, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 7.5612901081107449
        }, 
        {
            "AvEvapoTrans": 0.12423922451515659, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 8.8146466666666665, 
            "AvRunoff": 4.3095558277149308, 
            "AvGroundWater": 4.4765275700140306, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 8.7860833977289623
        }, 
        {
            "AvEvapoTrans": 0.39714380406925615, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 9.1177533333333312, 
            "AvRunoff": 1.3135896841011694, 
            "AvGroundWater": 6.5187939262689012, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 7.832383610370071
        }, 
        {
            "AvEvapoTrans": 0.86112729896448026, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 9.5885000000000016, 
            "AvRunoff": 1.4587623376350085, 
            "AvGroundWater": 7.4784852506567576, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 8.9372475882917666
        }, 
        {
            "AvEvapoTrans": 1.2612459760531187, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 9.4708133333333357, 
            "AvRunoff": 1.4531802779529208, 
            "AvGroundWater": 6.5918661660171782, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 8.045046443970099
        }, 
        {
            "AvEvapoTrans": 1.3330077518367922, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 10.43432, 
            "AvRunoff": 1.7673591792454091, 
            "AvGroundWater": 7.3123742784948425, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 9.079733457740252
        }, 
        {
            "AvEvapoTrans": 1.3010147671592545, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 8.917093333333332, 
            "AvRunoff": 1.2405284748886372, 
            "AvGroundWater": 7.1058308165792594, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 8.3463592914678966
        }, 
        {
            "AvEvapoTrans": 0.88421398753748692, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 8.2634666666666661, 
            "AvRunoff": 1.4093013727041257, 
            "AvGroundWater": 5.7326259896486818, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 7.1419273623528072
        }, 
        {
            "AvEvapoTrans": 0.36952113317431251, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 6.970606666666666, 
            "AvRunoff": 1.8687384714854796, 
            "AvGroundWater": 5.8528490756282432, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 7.7215875471137227
        }, 
        {
            "AvEvapoTrans": 0.22158317071743253, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 8.3278133333333315, 
            "AvRunoff": 3.4308773445042378, 
            "AvGroundWater": 5.1937941711655746, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 8.6246715156698119
        }, 
        {
            "AvEvapoTrans": 0.1047225596104919, 
            "AvTileDrain": 0.0, 
            "AvPrecipitation": 8.8070266666666672, 
            "AvRunoff": 3.7644152514963496, 
            "AvGroundWater": 5.2122698467996713, 
            "AvPtSrcFlow": 0.0, 
            "AvWithdrawal": 0.0, 
            "AvStreamFlow": 8.97668509829602
        }
    ], 
    "meta": {
        "NRur": 10, 
        "SedDelivRatio": 0.1966044129887173, 
        "NLU": 16, 
        "NUrb": 6, 
        "WxYrBeg": 1961, 
        "NYrs": 30, 
        "WxYrEnd": 1990
    }, 
    "MeanFlowPerSecond": 0.031519114793278687, 
    "AreaTotal": 100.04223109168646, 
    "Loads": [
        {
            "Source": "Hay/Pasture", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0.0
        }, 
        {
            "Source": "Cropland", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0.0
        }, 
        {
            "Source": "Wooded Areas", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0.0
        }, 
        {
            "Source": "Wetlands", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0.0
        }, 
        {
            "Source": "Open Land", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0.0
        }, 
        {
            "Source": "Barren Areas", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0.0
        }, 
        {
            "Source": "Low-Density Mixed", 
            "TotalN": 0.22440635401040207, 
            "TotalP": 0.025052872894268247, 
            "Sediment": 8.1722587632847183
        }, 
        {
            "Source": "Medium-Density Mixed", 
            "TotalN": 22.254169401691719, 
            "TotalP": 2.3284983828597241, 
            "Sediment": 634.91950925466199
        }, 
        {
            "Source": "High-Density Mixed", 
            "TotalN": 142.18771322423166, 
            "TotalP": 14.877385640821862, 
            "Sediment": 4056.6669316136795
        }, 
        {
            "Source": "Other Upland Areas", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0.0
        }, 
        {
            "Source": "Farm Animals", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0
        }, 
        {
            "Source": "Stream Bank Erosion", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0.0
        }, 
        {
            "Source": "Subsurface Flow", 
            "TotalN": 12419.161614119226, 
            "TotalP": 85.366559455811412, 
            "Sediment": 0
        }, 
        {
            "Source": "Point Sources", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0
        }, 
        {
            "Source": "Septic Systems", 
            "TotalN": 0.0, 
            "TotalP": 0.0, 
            "Sediment": 0
        }, 
        {
            "Source": "Total Loads", 
            "TotalN": 12583.82790309916, 
            "TotalP": 102.59749635238727, 
            "Sediment": 4699.7586996316268
        }, 
        {
            "Source": "Loading Rates", 
            "TotalN": 125.78515858534146, 
            "TotalP": 1.0255418659981599, 
            "Sediment": 46.977747780578817
        }, 
        {
            "Source": "Mean Annual Concentration", 
            "TotalN": 12.659954690474315, 
            "TotalP": 0.10321816741131981, 
            "Sediment": 4.728190233660575
        }, 
        {
            "Source": "Mean Low-Flow Concentration", 
            "TotalN": 14.96009155483976, 
            "TotalP": 0.14773484715808166, 
            "Sediment": 0.0
        }
    ]
}
```

## Notes

Since this is technically incorrect input, I'm not 100% sure we should be supporting this use case. It may be better to simply add an error message in https://github.com/WikiWatershed/model-my-watershed/issues/1330 for these cases. Alternatively, if we do use this, we should most definitely add a disclaimer warning to be shown to the user.

Connects #61 