### PR TITLE
Return Mean Low Flow Concentration

### DIFF
--- a/gwlfe/WriteOutputFiles.py
+++ b/gwlfe/WriteOutputFiles.py
@@ -759,7 +759,7 @@ def WriteOutput(z):
     ConcP = (SumPhos * KG_TO_MG) / (MeanFlow * M3_TO_L)
 
     # mg/l
-    LFConcSed = (z.AvLuSedYield[LowFlowMonth] * KG_TO_MG) / (MeanLowFlow * M3_TO_L)
+    LFConcSed = (z.AvSedYield[LowFlowMonth] * KG_TO_MG) / (MeanLowFlow * M3_TO_L)
     LFConcN = (z.AvTotNitr[LowFlowMonth] * KG_TO_MG) / (MeanLowFlow * M3_TO_L)
     LFConcP = (z.AvTotPhos[LowFlowMonth] * KG_TO_MG) / (MeanLowFlow * M3_TO_L)
 

--- a/test/input_4.output
+++ b/test/input_4.output
@@ -159,7 +159,7 @@
             "Source": "Mean Low-Flow Concentration", 
             "TotalN": 14.804110709397358, 
             "TotalP": 1.3626915312075798, 
-            "Sediment": 0.0, 
+            "Sediment": 0.30434608423836917, 
             "Unit": "mg/l"
         }
     ], 


### PR DESCRIPTION
This PR fixes a bug whereby Mean Low Flow Concentration would always return 0 due to a typo in the expression used to assign it. Currently, the code uses a month index to find a value in an array of average sediment yield by land use type; fixing the bug involved changing that array to a similarly-named array of months for `AvSedYield`.

The second commit here updates the test output file with the new proper values.

**Testing**
- get this branch, then run `python run.py test/input_4.gms` and verify that the `'Sediment'` key's value in `'Mean Low Flow Concentration'` is not zero:

```
{
            "Source": "Mean Low-Flow Concentration", 
            "TotalN": 14.804110709397358, 
            "TotalP": 1.3626915312075798, 
            "Sediment": 0.30434608423836917, 
            "Unit": "mg/l"
        }
```

- run `python setup.py test` and verify that there are no failed tests.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/1369