### PR TITLE
Update README to clarify release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,16 @@ $ git flow release publish 0.1.0
 $ git flow release finish 0.1.0
 ```
 
-To kick off the deployment, you'll still need to push the local tags remotely
-`git push --tags`
+After you've completed the `git flow` steps, you'll need to push the changes from your local `master` and `develop` branches back to the main repository.
+
+```bash
+$ git checkout develop
+$ git push origin develop
+$ git checkout master
+$ git push origin master
+# Trigger PyPi deployment
+$ git push --tags
+```
 
 ## License
 


### PR DESCRIPTION
PR adds the `git push master` and `git push develop` steps to the release process and clarifies that `git push --tags` should be the last step.