### PR TITLE
Fix low flow sediment value calculation

### DIFF
--- a/gwlfe/WriteOutputFiles.py
+++ b/gwlfe/WriteOutputFiles.py
@@ -759,7 +759,7 @@ def WriteOutput(z):
     ConcP = (SumPhos * KG_TO_MG) / (MeanFlow * M3_TO_L)
 
     # mg/l
-    LFConcSed = (z.AvSedYield[LowFlowMonth] * KG_TO_MG) / (MeanLowFlow * M3_TO_L)
+    LFConcSed = (z.AvSedYield[LowFlowMonth] * TONNE_TO_KG * KG_TO_MG) / (MeanLowFlow * M3_TO_L)
     LFConcN = (z.AvTotNitr[LowFlowMonth] * KG_TO_MG) / (MeanLowFlow * M3_TO_L)
     LFConcP = (z.AvTotPhos[LowFlowMonth] * KG_TO_MG) / (MeanLowFlow * M3_TO_L)
 

--- a/gwlfe/WriteOutputFiles.py
+++ b/gwlfe/WriteOutputFiles.py
@@ -889,7 +889,7 @@ def WriteOutput(z):
         'TotalP': z.AvSeptPhos * z.RetentFactorP * (1 - z.AttenP),
     })
 
-    output['SummaryLoads'] = []    
+    output['SummaryLoads'] = []
     output['SummaryLoads'].append({
         'Source': 'Total Loads',
         'Unit': 'kg',

--- a/test/input_4.output
+++ b/test/input_4.output
@@ -159,7 +159,7 @@
             "Source": "Mean Low-Flow Concentration", 
             "TotalN": 14.804110709397358, 
             "TotalP": 1.3626915312075798, 
-            "Sediment": 0.30434608423836917, 
+            "Sediment": 304.3460842383692,
             "Unit": "mg/l"
         }
     ], 


### PR DESCRIPTION
Sediment is in tonnes, so it first needs be converted from tonnes to
kilograms before being converted from kilograms to milligrams.

This change is based on the sample calculations in
https://drive.google.com/a/azavea.com/file/d/0B0hs2mX4ApaLYXBPS2RwTG1JZ1FOZ2UybXpBTEdaU2VaWVdz/view,
as well as Barry's comments in https://github.com/WikiWatershed/model-my-watershed/issues/1441.

With the sample GMS file, this change produces the following change in the output:

```diff
-            "Sediment": 0.30434608423836917, 
+            "Sediment": 304.3460842383692,
```

**Testing**
- Inspect the calculation and the referenced document and verify the change is correct.
- Run the tests and verify they pass.

Connects to https://github.com/WikiWatershed/model-my-watershed/issues/1441
