### PR TITLE
Fix manured nit/phos concentration transposition

### DIFF
--- a/gwlfe/parser.py
+++ b/gwlfe/parser.py
@@ -602,11 +602,8 @@ class GmsReader(object):
         # Lines 71 - 72: (for the 2 Manure Spreading Periods)
         for i in range(z.ManuredAreas):
             z.ManNitr[i] = self.next(float)  # Manured N Concentration
-        self.next(EOL)
-
-        for i in range(z.ManuredAreas):
             z.ManPhos[i] = self.next(float)  # Manured P Concentration
-        self.next(EOL)
+            self.next(EOL)
 
         # Lines 73 - 84: (Point Source data for each Month)
         z.PointNitr = np.zeros(12)
@@ -1476,8 +1473,8 @@ class GmsWriter(object):
                     z.UrbBMPRed[u][q],
                 ])
 
-        self.writerow(z.ManNitr)
-        self.writerow(z.ManPhos)
+        for i in range(z.ManuredAreas):
+            self.writerow([z.ManNitr[i], z.ManPhos[i]])
 
         for i in range(12):
             self.writerow([


### PR DESCRIPTION
This fixes a bug in the GMS parser that transposed the manured nitrogen & phosphorus concentrations, which resulted in incorrect calculations for nitrogen and phosphorus load in cropland and pasture land-use types.

To test, clone this branch and download this GMS file -->
[cropland_hay-pasture_issue.gms.txt](https://github.com/WikiWatershed/gwlf-e/files/477369/cropland_hay-pasture_issue.gms.txt)

Remove the `.txt` extension from the GMS file, then execute `run.py` with the file as the argument. The values for total & dissolved  nitrogen and phosphorus in pasture and cropland land types should equal the original GWLF-E values; no other land types should be affected.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/1373