### PR TITLE
Set initial value for `z.AdjUrbanQTotal` if unset

### DIFF
--- a/gwlfe/datamodel.py
+++ b/gwlfe/datamodel.py
@@ -105,6 +105,7 @@ class DataModel(object):
             'Storm': 0,
             'CSNAreaSim': 0,
             'CSNDevType': 'None',
+            'AdjUrbanQTotal': 0,
         }
 
     def date_guides(self):


### PR DESCRIPTION
This PR fixes an error whereby GWLF-E could try to perform calculations with `z.AdjUrbanQTotal` before the attribute had been set. The failing operation happens if `z.Water < 0.05`, and the `BasinWater` method gets called here -- https://github.com/WikiWatershed/gwlf-e/blob/develop/gwlfe/CalcCnErosRunoffSed.py#L101 -- which seems to affect watersheds in South Florida like the one linked in https://github.com/WikiWatershed/model-my-watershed/issues/1383

The fix sets `z.AdjUrbanQTotal` to 0 if z does not already have the attribute `AdjUrbanQTotal`. This enables GWLF-E to handle the South Florida GMS file attached in the original issue, and doesn't change the values output for the test GMS file.

**Testing**
- get this branch, then run `python setup.py test` and verify that the tests pass
- run `python run.py` on this GMS file and verify that it works:

[RoyalGladesCanal.gms.txt](https://github.com/WikiWatershed/gwlf-e/files/480049/RoyalGladesCanal.gms.txt)

Connects https://github.com/WikiWatershed/model-my-watershed/issues/1383