### PR TITLE
Update README release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Deployments to PyPi are handled through [Travis-CI](https://travis-ci.org/WikiWa
 $ git flow release start 0.1.0
 $ vim CHANGELOG.md
 $ vim setup.py
+$ git add CHANGELOG.md setup.py
 $ git commit -m "0.1.0"
 $ git flow release publish 0.1.0
 $ git flow release finish 0.1.0


### PR DESCRIPTION
The README was missing one step from the release instructions: actually `git add`ing the CHANGELOG and setup.py files to commit with the release. This PR adds that line so the instructions will be complete next time we make a release.

Connects #74 