### PR TITLE
Update build, publish mechanism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,10 @@ on:
       - '*'
 
 jobs:
-  deploy:
+  release:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10
@@ -27,5 +28,3 @@ jobs:
         pipenv run python -m cibuildwheel --output-dir dist
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Install pipenv, build dependencies
+      run: |
+        python -m pip install pipenv
+        pipenv install --dev
+    - name: Build source package
+      run: |
+        pipenv run python -m build --sdist
+    - name: Build wheels
+      run: |
+        pipenv run python -m cibuildwheel --output-dir dist
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -1,1 +1,0 @@
-A Python port of Generalized Watersheds Loading Functions - Enhanced (MapShed)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include DESCRIPTION.rst
 include *.md
 include *.py
 include LICENSE

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ numba = "==0.55.*"
 
 [dev-packages]
 build = "*"
+cibuildwheel = "*"
 twine = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e59d9200677cf335ca172f3bb3fc3342126c796a47b24885d03a22a3b5fc7796"
+            "sha256": "8aef7ea5d8bc275f2f117c858f5d4aac5887ad94a2dc40a45ca49e7d225d6ad1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -151,11 +151,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:01a1e793faa5bd89abc851fa15d0a0db26f160890c7102cd8dce643e886b47f5",
-                "sha256:d9b8b771455a97c8a9f3ab3448ebe0b29b5e105f1228bba41028be116985a267"
+                "sha256:937a48c7cdb7a21eb53cd7f9b59e525503aa8abaf3584c730dc5f7a5bec3a650",
+                "sha256:a58a8fde0541dab0419750bcc521fbdf8585f6e5cb41909df3a472ef7b81ca95"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==70.1.0"
+            "version": "==70.1.1"
         }
     },
     "develop": {
@@ -166,6 +166,22 @@
             ],
             "markers": "python_version < '3.12'",
             "version": "==1.2.0"
+        },
+        "bashlex": {
+            "hashes": [
+                "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee",
+                "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.18"
+        },
+        "bracex": {
+            "hashes": [
+                "sha256:a27eaf1df42cf561fed58b7a8f3fdf129d1ea16a81e1fadd1d17989bc6384beb",
+                "sha256:efdc71eff95eaff5e0f8cfebe7d01adf2c8637c8c92edaf63ef348c241a82418"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.4"
         },
         "build": {
             "hashes": [
@@ -338,6 +354,15 @@
             "markers": "python_full_version >= '3.7.0'",
             "version": "==3.3.2"
         },
+        "cibuildwheel": {
+            "hashes": [
+                "sha256:b6cd9c09ddda4b8a77e93550e8c7cd423e3850ec7ba008ee1dbcb4848e9ee6c1",
+                "sha256:c60a8e9aa0322b13f5965a8396fcabb64ce0f45b2f7130273b2589f6066034be"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2.19.1"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:013629ae70b40af70c9a7a5db40abe5d9054e6f4380e50ce769947b73bf3caad",
@@ -384,6 +409,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==0.21.2"
         },
+        "filelock": {
+            "hashes": [
+                "sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb",
+                "sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.15.4"
+        },
         "idna": {
             "hashes": [
                 "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
@@ -394,11 +427,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:509ecb2ab77071db5137c655e24ceb3eee66e7bbc6574165d0d114d9fc4bbe68",
-                "sha256:ffef94b0b66046dd8ea2d619b701fe978d9264d38f3998bc4c27ec3b146a87c8"
+                "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f",
+                "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.2.1"
+            "version": "==8.0.0"
         },
         "jaraco.classes": {
             "hashes": [
@@ -495,11 +528,19 @@
         },
         "pkginfo": {
             "hashes": [
-                "sha256:2e0dca1cf4c8e39644eed32408ea9966ee15e0d324c62ba899a393b3c6b467aa",
-                "sha256:bfa76a714fdfc18a045fcd684dbfc3816b603d9d075febef17cb6582bea29573"
+                "sha256:5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
+                "sha256:889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.10.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee",
+                "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.11.1"
+            "version": "==4.2.2"
         },
         "pycparser": {
             "hashes": [
@@ -583,12 +624,20 @@
         },
         "twine": {
             "hashes": [
-                "sha256:4d74770c88c4fcaf8134d2a6a9d863e40f08255ff7d8e2acb3cbbd57d25f6e9d",
-                "sha256:fe1d814395bfe50cfbe27783cb74efe93abeac3f66deaeb6c8390e4e92bacb43"
+                "sha256:215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
+                "sha256:9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==5.1.0"
+            "version": "==5.1.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==4.12.2"
         },
         "urllib3": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Install using `pip`:
 $ pip install gwlf-e
 ```
 
+For Linux x64 on Python 3.8, 3.9, and 3.10 the above will pull a published wheel.
+For other platforms, a wheel would have to be built.
+In that case, you may also need to install `setuptools`, `wheel`, and `build` to compile it locally:
+
+```bash
+$ pip install wheel build
+$ pip install --no-build-isolation gwlf-e
+```
+
 ## Development
 
 Ensure you have Python 3.10 and [pipenv](https://pipenv.pypa.io/en/latest/) available. Then run:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # gwlf-e
 Port of Generalized Watersheds Loading Functions - Enhanced (MapShed)
 
-[![Build Status](https://travis-ci.org/WikiWatershed/gwlf-e.svg?branch=develop)](https://travis-ci.org/WikiWatershed/gwlf-e)
-
 ## Installation
 
 Install using `pip`:
@@ -41,49 +39,10 @@ $ vim CHANGELOG.md
 $ vim setup.py
 $ git add CHANGELOG.md setup.py
 $ git commit -m "3.0.0"
-$ git flow release publish 3.0.0
-```
-
-Then create a wheel to publish to PyPI using [build](https://github.com/pypa/build):
-
-```console
-$ pipenv run python -m build
-```
-
-This should create two files under `dist/`:
-
-```console
-$ ls -1 dist/
-gwlf-e-3.0.0.tar.gz
-gwlf_e-3.0.0-cp39-cp39-macosx_11_0_x86_64.whl
-```
-
-Then publish the wheel to PyPI using [twine](https://github.com/pypa/twine/) and credentials from LastPass:
-
-```console
-$ python -m twine check dist/*
-Checking dist/gwlf_e-3.0.0-cp39-cp39-macosx_11_0_x86_64.whl: PASSED
-Checking dist/gwlf-e-3.0.0.tar.gz: PASSED
-```
-```console
-$ python -m twine upload dist/*
-Uploading distributions to https://upload.pypi.org/legacy/
-Enter your username: azavea
-Enter your password:
-Uploading gwlf_e-3.0.0-cp39-cp39-macosx_11_0_x86_64.whl
-100%|
-Uploading gwlf-e-3.0.0.tar.gz
-100%|
-
-View at:
-https://pypi.org/project/gwlf-e/3.0.0/
-```
-
-Finally, finish the release:
-
-```console
 $ git flow release finish -p 3.0.0
 ```
+
+When the tag is pushed up, [GitHub Actions](./.github/workflows/release.yml) will publish a release to PyPI.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,11 @@
 requires = [
     "setuptools>=42",
     "wheel>=0.31",
+    "cibuildwheel>=2.13",
     "twine>=1.11",
     'numba==0.55.*',
 ]
+
+[tool.cibuildwheel]
+build = "cp38-manylinux_* cp39-manylinux_* cp310-manylinux_*"
+archs = "x86_64"

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ from gwlfe.BMPs.Stream.UrbLoadRed_inner import cc as ulrcc
 from gwlfe.MultiUse_Fxns.Runoff.WashImperv_inner import cc as wipcc
 from gwlfe.MultiUse_Fxns.Runoff.WashPerv_inner import cc as wpcc
 
-# Get the long description from DESCRIPTION.rst
+# Get the long description from README.md
 with open(path.join(path.abspath(path.dirname(__file__)),
-                    'DESCRIPTION.rst'), encoding='utf-8') as f:
+                    'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 tests_require = [
@@ -36,7 +36,7 @@ setup(
     version='3.1.0',
     description='A Python port of Generalized Watersheds Loading Functions - Enhanced (MapShed)',
     long_description=long_description,
-    long_description_content_type='text/x-rst',
+    long_description_content_type='text/markdown',
     url='https://github.com/WikiWatershed/gwlf-e',
     author='Azavea Inc.',
     author_email='systems@azavea.com',


### PR DESCRIPTION
## Overview

Since gwlf-e is primarily installed on Linux VMs for MMW, it is useful for there to be binary Linux wheels for common Python versions available.

This PR builds and publishes binary Linux wheels for Python 3.8 (current version on MMW), 3.9, and 3.10 (next version on MMW).

It also adds a GitHub Action to do releases instead of the previous manual process, and updates the README. PyPI has been configured to trust this new GitHub Action as a publisher as well.

### Demo

https://test.pypi.org/project/gwlf-e/3.2.0/

## Testing Instructions

- Ensure you are in a Python 3.10 environment and have pipenv installed
- Check out this repo
- Run `pipenv sync --dev` to install all dependencies
- Run `pipenv run python -m build --sdist` to build a source distribution
- Run `pipenv run python -m cibuildwheel --output-dir dist` to build wheels
- In a Python 3.10 virtual environment, install the gwlf-e 3.2.0 from TestPyPI
    ```
    pip install -i https://test.pypi.org/simple/ gwlf-e==3.2.0
    ```
  - [ ] Ensure it works

Closes #92 